### PR TITLE
chore: support mainnet bridges (eth_truf, eth_usdc)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -916,11 +916,20 @@ The SDK provides methods for interacting with bridge instances on TN, enabling t
 
 ### Understanding Bridge Identifiers
 
-Bridge instances on TN are identified by specific names that may differ from network names. For example:
-- Network `"sepolia"` → Bridge identifier `"sepolia"` (matches)
-- Network `"hoodi"` → Bridge identifier `"hoodi_tt"` (different due to multiple token support)
+Bridge instances on TN are identified by specific names that may differ from network names. Always use the **bridge identifier** when calling bridge methods, not the network name.
 
-Always use the **bridge identifier** when calling bridge methods, not the network name.
+#### Mainnet vs testnet identifiers
+
+| Identifier | Network | Token | Decimals | Notes |
+|---|---|---|---|---|
+| `eth_truf` | mainnet | TRUF | 18 | Used for protocol fees (stream write, attestation, market creation) |
+| `eth_usdc` | mainnet | USDC | 6 | Used for prediction-market collateral |
+| `ethereum_bridge` | mainnet | TRUF | 18 | Legacy — replaced by `eth_truf` |
+| `hoodi_tt` | testnet | TRUF (test) | 18 | Hoodi testnet |
+| `hoodi_tt2` | testnet | USDC (test) | 18 | Hoodi testnet — prediction-market collateral |
+| `sepolia_bridge` | testnet | TRUF (test) | 18 | Sepolia testnet, deprecated |
+
+Examples below use testnet identifiers; substitute the mainnet equivalent for production. Order-book actions (`createMarket`, `placeBuyOrder`, etc.) accept `"eth_usdc"` or `"eth_truf"` as the `bridge` field on mainnet.
 
 ### `client.getWalletBalance(bridgeIdentifier: string, walletAddress: string): Promise<string>`
 

--- a/src/types/orderbook.ts
+++ b/src/types/orderbook.ts
@@ -9,8 +9,16 @@
 // Bridge Types
 // ============================================
 
-/** Valid bridge identifiers for collateral */
+/**
+ * Valid bridge identifiers for collateral.
+ *
+ * `eth_usdc` (USDC) and `eth_truf` (TRUF) are the production mainnet bridges.
+ * The others are testnet / legacy aliases retained for local-node
+ * and integration test use. `ethereum_bridge` was the legacy mainnet TRUF bridge.
+ */
 export type BridgeIdentifier =
+  | "eth_usdc"
+  | "eth_truf"
   | "hoodi_tt2"
   | "sepolia_bridge"
   | "ethereum_bridge";

--- a/src/util/orderbookHelpers.ts
+++ b/src/util/orderbookHelpers.ts
@@ -390,11 +390,21 @@ export function validateAmount(amount: number, operation: string): void {
 /**
  * Validates a bridge identifier.
  *
+ * eth_usdc (USDC) and eth_truf (TRUF) are the production mainnet bridges;
+ * the others are testnet / legacy aliases retained for local-node and
+ * integration test use. ethereum_bridge was the legacy mainnet TRUF bridge.
+ *
  * @param bridge - Bridge identifier to validate
  * @throws Error if bridge is invalid
  */
 export function validateBridge(bridge: string): void {
-  const validBridges = ["hoodi_tt2", "sepolia_bridge", "ethereum_bridge"];
+  const validBridges = [
+    "eth_usdc",
+    "eth_truf",
+    "hoodi_tt2",
+    "sepolia_bridge",
+    "ethereum_bridge",
+  ];
   if (!validBridges.includes(bridge)) {
     throw new Error(
       `Invalid bridge: ${bridge}. Must be one of: ${validBridges.join(", ")}`


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new production mainnet bridge identifiers available for use in order-book operations.

* **Documentation**
  * Significantly enhanced API reference documentation with a comprehensive lookup table listing all supported bridge identifiers, explicit distinction between production mainnet and testnet/legacy options, clear flagging of deprecated entries, and practical guidance on translating testnet identifiers to their mainnet equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->