### PR TITLE
feat: read a market's details from a create_market transaction

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -145,9 +145,10 @@ export {
   hexToBytes,
   bytesToHex,
   decodeMarketData,
+  decodeCreateMarketPayload,
 } from "./util/orderbookHelpers";
 
-export type { MarketData } from "./util/orderbookHelpers";
+export type { MarketData, CreateMarketPayload } from "./util/orderbookHelpers";
 
 // Local actions types
 export type {

--- a/src/util/orderbookHelpers.test.ts
+++ b/src/util/orderbookHelpers.test.ts
@@ -13,7 +13,9 @@ import {
   validateMaxSpread,
   validateSettleTime,
   settledFilterToBoolean,
+  decodeCreateMarketPayload,
 } from "./orderbookHelpers";
+import type { DecodedTransactionPayload } from "./TransactionPayload";
 
 // Valid 32-character stream ID for testing
 const TEST_STREAM_ID = "stbtc000000000000000000000000000"; // exactly 32 chars
@@ -370,6 +372,88 @@ describe("orderbookHelpers", () => {
         const decoded = decodeMarketData(encoded);
         expect(decoded.type).toBe("equals");
         expect(decoded.thresholds).toEqual([target, tolerance]);
+    });
+  });
+
+  describe("decodeCreateMarketPayload", () => {
+    const buildQueryComponents = () =>
+      encodeQueryComponents(
+        TEST_DATA_PROVIDER,
+        TEST_STREAM_ID,
+        "price_above_threshold",
+        encodeActionArgs(TEST_DATA_PROVIDER, TEST_STREAM_ID, 1700000000, "50.00", 0)
+      );
+
+    // A create_market call as decodeTransactionPayload surfaces it: create_market's on-chain
+    // signature is ($bridge TEXT, $query_components BYTEA, $settle_time INT8, $max_spread INT,
+    // $min_order_size INT8), so args decode to string, Uint8Array, and bigint (INT/INT8) respectively.
+    const createMarketTx = (
+      queryComponents: Uint8Array
+    ): DecodedTransactionPayload => ({
+      namespace: "main",
+      action: "create_market",
+      arguments: [
+        // min_order_size is 1e18 + 1: NOT exactly representable as an IEEE-754 double, so it pins
+        // that the field is kept as a string (a String(Number(...)) regression would drop the +1).
+        ["hoodi_tt2", queryComponents, 1700003600n, 10n, 1000000000000000001n],
+      ],
+    });
+
+    it("decodes a create_market transaction into structured fields", () => {
+      const queryComponents = buildQueryComponents();
+      const decoded = decodeCreateMarketPayload(createMarketTx(queryComponents));
+
+      expect(decoded).not.toBeNull();
+      expect(decoded!.bridge).toBe("hoodi_tt2");
+      expect(decoded!.settleTime).toBe(1700003600);
+      expect(decoded!.maxSpread).toBe(10);
+      expect(decoded!.minOrderSize).toBe("1000000000000000001");
+      expect(decoded!.queryComponents).toEqual(queryComponents);
+    });
+
+    it("decodes the nested market details from query_components", () => {
+      const decoded = decodeCreateMarketPayload(createMarketTx(buildQueryComponents()));
+
+      expect(decoded!.market).not.toBeNull();
+      expect(decoded!.market!.type).toBe("above");
+      expect(decoded!.market!.thresholds).toEqual(["50.00"]);
+      expect(decoded!.market!.streamId).toBe(TEST_STREAM_ID);
+      expect(decoded!.market!.dataProvider).toBe(TEST_DATA_PROVIDER.toLowerCase());
+    });
+
+    it("keeps the top-level fields and leaves market null when query_components can't be decoded", () => {
+      // A committed-but-execution-failed create_market can still carry empty/garbage
+      // query_components; an explorer must get the top-level fields, not an opaque crash.
+      const badTx: DecodedTransactionPayload = {
+        namespace: "main",
+        action: "create_market",
+        arguments: [
+          ["hoodi_tt2", new Uint8Array(), 1700003600n, 10n, 1000000000000000000n],
+        ],
+      };
+      const decoded = decodeCreateMarketPayload(badTx);
+      expect(decoded).not.toBeNull();
+      expect(decoded!.market).toBeNull();
+      expect(decoded!.bridge).toBe("hoodi_tt2");
+      expect(decoded!.settleTime).toBe(1700003600);
+    });
+
+    it("returns null when the transaction is not a create_market", () => {
+      const notMarket: DecodedTransactionPayload = {
+        namespace: "main",
+        action: "insert_records",
+        arguments: [["0xabc", "stream"]],
+      };
+      expect(decodeCreateMarketPayload(notMarket)).toBeNull();
+    });
+
+    it("throws when a create_market call is missing arguments", () => {
+      const truncated: DecodedTransactionPayload = {
+        namespace: "main",
+        action: "create_market",
+        arguments: [["hoodi_tt2"]],
+      };
+      expect(() => decodeCreateMarketPayload(truncated)).toThrow(/create_market/);
     });
   });
 });

--- a/src/util/orderbookHelpers.ts
+++ b/src/util/orderbookHelpers.ts
@@ -11,6 +11,7 @@ import {
   decodeActionArgs,
   decodeQueryComponents
 } from "./AttestationEncoding";
+import type { DecodedTransactionPayload } from "./TransactionPayload";
 
 /**
  * Structured content of a prediction market's query components
@@ -78,6 +79,97 @@ export function decodeMarketData(encoded: string | Uint8Array): MarketData {
   }
 
   return market;
+}
+
+/**
+ * A decoded `create_market` transaction: its five action arguments turned into structured fields,
+ * with the ABI-encoded `query_components` further decoded into {@link MarketData}. Returned by
+ * {@link decodeCreateMarketPayload}.
+ */
+export interface CreateMarketPayload {
+  /** Collateral bridge namespace, e.g. `"eth_usdc"` / `"hoodi_tt2"`. */
+  bridge: string;
+  /** The raw ABI-encoded query_components bytes (kept for hashing / re-decoding). */
+  queryComponents: Uint8Array;
+  /**
+   * The query_components decoded into a market type and its thresholds, or `null` when they can't
+   * be decoded — a committed-but-execution-failed create_market can carry empty/garbage
+   * query_components, and an explorer should still see the top-level fields.
+   */
+  market: MarketData | null;
+  /** Unix timestamp at which the market settles. */
+  settleTime: number;
+  /** Maximum bid-ask spread allowed, in cents. */
+  maxSpread: number;
+  /** Minimum order size in the bridge token's base units (string to avoid precision loss). */
+  minOrderSize: string;
+}
+
+/** The on-chain action name whose payload {@link decodeCreateMarketPayload} understands. */
+const CREATE_MARKET_ACTION = "create_market";
+
+/**
+ * Decodes a `create_market` transaction (as returned by `TransactionAction.getTransactionInput`)
+ * into a structured {@link CreateMarketPayload}, including the market details nested inside its
+ * ABI-encoded `query_components` argument.
+ *
+ * This is the transaction-level counterpart to `OrderbookAction.createMarket`: it knows
+ * create_market's argument order (`$bridge, $query_components, $settle_time, $max_spread,
+ * $min_order_size`), so a block explorer or indexer reading the transaction doesn't have to.
+ *
+ * @param payload - A decoded execute payload from `getTransactionInput` / `decodeTransactionPayload`.
+ * @returns The structured market creation, or `null` if `payload` is not a create_market call.
+ *   Its `market` field is `null` when the query_components can't be decoded (e.g. a
+ *   committed-but-failed create_market with empty/garbage components).
+ * @throws If the call is a create_market but does not carry its five expected arguments.
+ *
+ * @example
+ * ```typescript
+ * const payload = await client.loadTransactionAction().getTransactionInput({ txId });
+ * const created = decodeCreateMarketPayload(payload);
+ * if (created) {
+ *   console.log(created.market.type, created.market.thresholds, created.settleTime);
+ * }
+ * ```
+ */
+export function decodeCreateMarketPayload(
+  payload: DecodedTransactionPayload
+): CreateMarketPayload | null {
+  if (payload.action !== CREATE_MARKET_ACTION) {
+    return null;
+  }
+
+  const call = payload.arguments[0];
+  if (!call || call.length < 5) {
+    throw new Error(
+      `create_market payload must carry 5 arguments ` +
+        `($bridge, $query_components, $settle_time, $max_spread, $min_order_size), ` +
+        `got ${call?.length ?? 0}`
+    );
+  }
+
+  const [bridge, queryComponents, settleTime, maxSpread, minOrderSize] = call;
+  const queryComponentsBytes = dbBytesToUint8Array(
+    queryComponents as string | Uint8Array
+  );
+
+  let market: MarketData | null;
+  try {
+    market = decodeMarketData(queryComponentsBytes);
+  } catch {
+    // Non-fatal: a committed-but-execution-failed create_market can carry empty/garbage
+    // query_components. Surface the top-level fields with a null market rather than crashing.
+    market = null;
+  }
+
+  return {
+    bridge: String(bridge),
+    queryComponents: queryComponentsBytes,
+    market,
+    settleTime: Number(settleTime),
+    maxSpread: Number(maxSpread),
+    minOrderSize: String(minOrderSize),
+  };
 }
 
 /**


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/trufscan/issues/173

A block explorer reading a `create_market` transaction gets back its five raw action arguments, one of which (`query_components`) is a nested double-encoding — an ABI tuple wrapping a kwil-native argument blob. Decoding that meant knowing create_market's argument order and stitching two decoders together by hand. The SDK owns the *encode* side (`OrderbookAction.createMarket`, `encodeQueryComponents`), so it should own the symmetric decode.

Adds `decodeCreateMarketPayload(payload)`, the transaction-level counterpart to `createMarket`. Given a decoded execute payload (from `TransactionAction.getTransactionInput` / `decodeTransactionPayload`) it returns a structured `CreateMarketPayload`:

```ts
const payload = await client.loadTransactionAction().getTransactionInput({ txId });
const created = decodeCreateMarketPayload(payload);
if (created) {
  // { bridge, queryComponents, market: { type, thresholds, streamId, dataProvider },
  //   settleTime, maxSpread, minOrderSize }
}
```

- Returns `null` when the transaction isn't a `create_market` call, so callers branch cleanly.
- Throws when it *is* a `create_market` but doesn't carry its five arguments.
- The nested `query_components` are decoded to `MarketData` (type + thresholds) via the existing `decodeMarketData`. Decode is **non-fatal**: a committed-but-execution-failed create_market can carry empty/garbage components, so `market` is left `null` rather than crashing an explorer that's iterating a block.

The argument order (`$bridge, $query_components, $settle_time, $max_spread, $min_order_size`) matches the on-chain `create_market` signature in node migration `032-order-book-actions.sql`.

Test-first: four cases watched fail before the code existed — structured fields, the nested market decode, the null-when-not-create_market path, and the throw-on-truncated path. Also verified against the exact `query_components` byte vector from trufscan#173. `test:unit` (292), `typecheck`, and `build` are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decoding `create_market` transaction details into a structured, easy-to-use format.
  * Exposed additional market-related fields, including bridge, settlement timing, spread, minimum order size, and nested market data when available.

* **Bug Fixes**
  * Improved handling for malformed market details by preserving the main payload and safely returning no nested market data when decoding fails.
  * Returns no result for unrelated transaction actions and validates required inputs more strictly.

* **Tests**
  * Added coverage for successful decoding, missing fields, invalid actions, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->