### PR TITLE
feat: read a token's ranked wallet balances

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -980,6 +980,50 @@ const balanceInTokens = formatEther(hoodiBalance);
 console.log(`Balance: ${balanceInTokens} tokens`);
 ```
 
+### `client.getOrderedBalances(options: OrderedBalancesOptions): Promise<TokenBalance[]>`
+
+Gets a token's wallet balances in balance order — a "richlist". Where `getWalletBalance` reads one
+wallet on one bridge, this ranks every holder of a token and returns the top (or bottom) slice.
+
+#### Parameters
+- `options.token: "TRUF" | "USDC"` - Which token's balance ledger to rank
+- `options.ascending?: boolean` - Smallest balance first. Defaults to `false` (largest first)
+- `options.limit?: number` - How many wallets to return. Defaults to `20`, and the node clamps it to a maximum of **50** — asking for more returns 50 rather than failing
+- `options.minBalance?: string` - Only include wallets at or above this balance, in token base units. Defaults to no threshold
+
+#### Returns
+- `Promise<TokenBalance[]>` - Matching wallets ordered by balance, each `{ address, balance }`. `address` is 0x-prefixed lowercase hex; `balance` is in token base units (18 decimals for TRUF, 6 for USDC), as a string.
+
+Returns an empty array when no wallet clears the threshold — that is a legitimate result, not an error. An unsupported token throws.
+
+> **Balances are strings, and converting them to `number` loses data.** A real mainnet TRUF balance
+> such as `685701000000000000000000` has 24 digits, well past `Number.MAX_SAFE_INTEGER` (~9.0e15).
+> Use `BigInt` for arithmetic and `formatUnits` for display.
+
+#### Example
+```typescript
+// The 10 largest TRUF holders
+const top = await client.getOrderedBalances({ token: "TRUF", limit: 10 });
+for (const { address, balance } of top) {
+  console.log(`${address}: ${balance}`);
+}
+
+// The smallest USDC holders still holding at least 1 USDC (6 decimals)
+const small = await client.getOrderedBalances({
+  token: "USDC",
+  ascending: true,
+  limit: 5,
+  minBalance: "1000000",
+});
+
+// Comparing or summing balances — use BigInt, never Number
+const total = top.reduce((sum, r) => sum + BigInt(r.balance), 0n);
+
+// Display in human-readable units
+import { formatUnits } from 'ethers';
+console.log(`Top holder: ${formatUnits(top[0].balance, 18)} TRUF`);
+```
+
 ### `client.withdraw(bridgeIdentifier: string, amount: string, recipient: string): Promise<string>`
 
 Initiates a withdrawal by bridging tokens from TN to a destination chain. This is a convenience method that calls `bridgeTokens` and waits for transaction confirmation.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -5,7 +5,12 @@ import { deleteStream } from "../contracts-api/deleteStream";
 import { PrimitiveAction } from "../contracts-api/primitiveAction";
 import { Action, ListMetadataByHeightParams, MetadataQueryResult } from "../contracts-api/action";
 import { StreamType } from "../contracts-api/contractValues";
-import { WithdrawalProof, BridgeHistory } from "../types/bridge";
+import {
+  WithdrawalProof,
+  BridgeHistory,
+  OrderedBalancesOptions,
+  TokenBalance,
+} from "../types/bridge";
 import { StreamLocator, TNStream } from "../types/stream";
 import { EthereumAddress } from "../util/EthereumAddress";
 import { StreamId } from "../util/StreamId";
@@ -316,6 +321,17 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
   async getWalletBalance(bridgeIdentifier: string, walletAddress: string) {
     const action = this.loadAction();
     return action.getWalletBalance(bridgeIdentifier, walletAddress);
+  }
+
+  /**
+   * Gets a token's wallet balances in balance order — a "richlist"
+   * @param options Which token to rank, and how (sort direction, row count, minimum balance)
+   * @returns Promise resolving to the matching wallets ordered by balance, each with its balance
+   *   as a string in token base units. Empty if no wallet clears the threshold.
+   */
+  async getOrderedBalances(options: OrderedBalancesOptions): Promise<TokenBalance[]> {
+    const action = this.loadAction();
+    return action.getOrderedBalances(options);
   }
 
   /**

--- a/src/contracts-api/action.test.ts
+++ b/src/contracts-api/action.test.ts
@@ -157,3 +157,157 @@ describe("Action", () => {
         });
     });
 });
+
+/**
+ * Unit tests for getOrderedBalances (migration 053, the "richlist").
+ *
+ * The kwil client is mocked; this layer only forwards the call with the right action name, named
+ * params and types, and maps the returned rows. On-chain behaviour — including the hard cap of 50,
+ * which cannot be exercised against mainnet because no token has more than 24 holders — is covered
+ * by node/tests/streams/order_book/richlist_test.go.
+ *
+ * Three behaviours below are load-bearing rather than cosmetic, each documented in the design spec
+ * (0GoalViewTransactionsInExplorer/2026-07-21_sdk-js-ordered-balances-design.md):
+ *   - All four params are always sent. kwil-js resolves named params positionally, so omitting a
+ *     middle one silently shifts later arguments into the wrong slots (spec F1).
+ *   - $min_balance carries an explicit Numeric(78,0) type, without which the node rejects it as
+ *     text (spec F2).
+ *   - An unsupported token is rejected client-side, because kwil-js reports the node's ERROR as an
+ *     empty 200, making it otherwise indistinguishable from "no holders" (spec F3).
+ */
+describe("Action.getOrderedBalances", () => {
+    const mockSigner = { signatureType: "secp256k1_ep" } as unknown as KwilSigner;
+
+    const ok = (result: unknown) => ({ status: 200, data: { result } });
+
+    function makeAction(call: ReturnType<typeof vi.fn>) {
+        return new Action({ call } as unknown as NodeKwil, mockSigner);
+    }
+
+    /** A real mainnet TRUF balance: 24 digits, far beyond Number.MAX_SAFE_INTEGER (~9.0e15). */
+    const BIG_BALANCE = "685701000000000000000000";
+
+    it("calls get_ordered_balances and maps the returned rows", async () => {
+        const call = vi.fn().mockResolvedValue(
+            ok([
+                { address: "0xaaa", balance: BIG_BALANCE },
+                { address: "0xbbb", balance: "661171000000000000000000" },
+            ]),
+        );
+        const action = makeAction(call);
+
+        const balances = await action.getOrderedBalances({ token: "TRUF" });
+
+        expect(call).toHaveBeenCalledTimes(1);
+        const [body] = call.mock.calls[0];
+        expect(body.namespace).toBe("main");
+        expect(body.name).toBe("get_ordered_balances");
+        expect(balances).toEqual([
+            { address: "0xaaa", balance: BIG_BALANCE },
+            { address: "0xbbb", balance: "661171000000000000000000" },
+        ]);
+    });
+
+    it("preserves a 24-digit balance exactly, without routing it through a number", async () => {
+        const call = vi.fn().mockResolvedValue(ok([{ address: "0xaaa", balance: BIG_BALANCE }]));
+        const action = makeAction(call);
+
+        const [balance] = await action.getOrderedBalances({ token: "TRUF" });
+
+        // The guard: Number(BIG_BALANCE) rounds to 6.85701e+23 and drops the low-order digits.
+        expect(balance.balance).toBe(BIG_BALANCE);
+        expect(typeof balance.balance).toBe("string");
+    });
+
+    it("sends the node's own defaults when the caller omits the optional params", async () => {
+        const call = vi.fn().mockResolvedValue(ok([]));
+        const action = makeAction(call);
+
+        await action.getOrderedBalances({ token: "TRUF" });
+
+        const [body] = call.mock.calls[0];
+        // Pinned against migration 053: ascending=false, limit=20, min_balance=NULL. kwil-js
+        // resolves named params positionally, so each must be present and in the declared order.
+        expect(body.inputs).toEqual({
+            $token: "TRUF",
+            $ascending: false,
+            $limit: 20,
+            $min_balance: null,
+        });
+        expect(Object.keys(body.inputs)).toEqual([
+            "$token",
+            "$ascending",
+            "$limit",
+            "$min_balance",
+        ]);
+    });
+
+    it("types $min_balance as numeric(78,0) so the node does not reject it as text", async () => {
+        const call = vi.fn().mockResolvedValue(ok([]));
+        const action = makeAction(call);
+
+        await action.getOrderedBalances({ token: "USDC", minBalance: "1000000" });
+
+        const [body] = call.mock.calls[0];
+        expect(body.types.$min_balance).toEqual(
+            expect.objectContaining({ name: "numeric", metadata: [78, 0] }),
+        );
+        expect(body.inputs.$min_balance).toBe("1000000");
+    });
+
+    it("forwards ascending, limit and minBalance when supplied", async () => {
+        const call = vi.fn().mockResolvedValue(ok([]));
+        const action = makeAction(call);
+
+        await action.getOrderedBalances({
+            token: "USDC",
+            ascending: true,
+            limit: 5,
+            minBalance: "1000000",
+        });
+
+        const [body] = call.mock.calls[0];
+        expect(body.inputs).toEqual({
+            $token: "USDC",
+            $ascending: true,
+            $limit: 5,
+            $min_balance: "1000000",
+        });
+    });
+
+    it("rejects an unsupported token before making any call", async () => {
+        const call = vi.fn();
+        const action = makeAction(call);
+
+        await expect(
+            action.getOrderedBalances({ token: "ETH" as unknown as "TRUF" }),
+        ).rejects.toThrow(/unsupported token/i);
+
+        // The node reports its own ERROR as an empty 200, so a bad token would otherwise look
+        // identical to a token with no holders. Failing before the round trip is the fix.
+        expect(call).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array when no wallet clears the threshold", async () => {
+        const call = vi.fn().mockResolvedValue(ok([]));
+        const action = makeAction(call);
+
+        const balances = await action.getOrderedBalances({
+            token: "TRUF",
+            minBalance: "999999999999999999999999999",
+        });
+
+        // Deliberately unlike getWalletBalance, which throws on zero rows: for a richlist,
+        // "nobody is above your threshold" is a legitimate answer rather than a failure.
+        expect(balances).toEqual([]);
+    });
+
+    it("throws when the node returns a non-200 status", async () => {
+        const call = vi.fn().mockResolvedValue({ status: 500, data: undefined });
+        const action = makeAction(call);
+
+        await expect(action.getOrderedBalances({ token: "TRUF" })).rejects.toThrow(
+            /ordered balances/i,
+        );
+    });
+});

--- a/src/contracts-api/action.ts
+++ b/src/contracts-api/action.ts
@@ -1,6 +1,12 @@
-import {KwilSigner, NodeKwil, WebKwil, Types} from "@trufnetwork/kwil-js";
+import {KwilSigner, NodeKwil, WebKwil, Types, Utils} from "@trufnetwork/kwil-js";
 import { Either } from "monads-io";
-import { WithdrawalProof, BridgeHistory } from "../types/bridge";
+import {
+  WithdrawalProof,
+  BridgeHistory,
+  OrderedBalancesOptions,
+  TokenBalance,
+  RawTokenBalance,
+} from "../types/bridge";
 import { DateString } from "../types/other";
 import { StreamLocator } from "../types/stream";
 import { CacheAwareResponse, GetRecordOptions, GetIndexOptions, GetIndexChangeOptions, GetFirstRecordOptions } from "../types/cache";
@@ -142,16 +148,22 @@ export class Action {
 
   /**
    * Calls a method on the stream
+   *
+   * @param types - Optional explicit types for the named params. Needed when a value's type cannot
+   *   be inferred from its JavaScript representation — notably NUMERIC(78,0) arguments, which are
+   *   carried as strings and are otherwise rejected by the node as text.
    */
   protected async call<T>(
     method: string,
     inputs: Types.NamedParams,
+    types?: Record<string, any>,
   ): Promise<Either<number, T>> {
     const result = await this.kwilClient.call(
       {
         namespace: "main",
         name: method,
         inputs: inputs,
+        ...(types ? { types } : {}),
       },
       this.kwilSigner,
     );
@@ -1064,6 +1076,77 @@ export class Action {
 
         return row.balance;
       })
+      .throw();
+  }
+
+  /**
+   * Gets a token's wallet balances in balance order — a "richlist" (get_ordered_balances,
+   * migration 053).
+   *
+   * Where {@link getWalletBalance} reads one wallet on one bridge, this ranks every holder of a
+   * token and returns the top (or bottom) slice.
+   *
+   * @example
+   * ```typescript
+   * // The 10 largest TRUF holders
+   * const top = await action.getOrderedBalances({ token: "TRUF", limit: 10 });
+   *
+   * // The smallest USDC holders still holding at least 1 USDC (6 decimals)
+   * const small = await action.getOrderedBalances({
+   *   token: "USDC",
+   *   ascending: true,
+   *   minBalance: "1000000",
+   * });
+   * ```
+   *
+   * @param options - Which token to rank, and how. See {@link OrderedBalancesOptions}.
+   * @returns The matching wallets, ordered by balance. Empty when the token has no holders above
+   *   the threshold — which is a legitimate result here, not an error.
+   * @throws If the token is not one the node supports, or the query fails.
+   */
+  public async getOrderedBalances(
+    options: OrderedBalancesOptions
+  ): Promise<TokenBalance[]> {
+    const token = options.token?.toUpperCase();
+    // Validated here rather than left to the node: the node does raise an error for an unknown
+    // token, but kwil-js surfaces it as an empty 200, which is indistinguishable from a token
+    // that simply has no holders. Failing before the round trip keeps the two apart.
+    if (token !== "TRUF" && token !== "USDC") {
+      throw new Error(
+        `unsupported token (want TRUF or USDC): ${options.token}`
+      );
+    }
+
+    // Every parameter is sent, including the ones the node would default, because kwil-js resolves
+    // named params positionally — omitting a middle one shifts the later arguments into the wrong
+    // slots. These defaults mirror migration 053 and are pinned by a unit test.
+    const inputs = {
+      $token: token,
+      $ascending: options.ascending ?? false,
+      $limit: options.limit ?? 20,
+      $min_balance: options.minBalance ?? null,
+    };
+
+    // NUMERIC(78,0) is carried as a string and must be typed explicitly; the node rejects an
+    // untyped string as text.
+    const types = { $min_balance: Utils.DataType.Numeric(78, 0) };
+
+    const result = await this.call<RawTokenBalance[]>(
+      "get_ordered_balances",
+      inputs,
+      types
+    );
+
+    return result
+      .mapRight((rows) =>
+        (rows ?? []).map((row) => ({
+          address: row.address,
+          balance: row.balance,
+        }))
+      )
+      .mapLeft(
+        (status) => new Error(`Failed to get ordered balances: ${status}`)
+      )
       .throw();
   }
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -88,7 +88,12 @@ export type {
 } from "./types/attestation";
 
 // Bridge types
-export type { WithdrawalProof } from "./types/bridge";
+export type {
+  WithdrawalProof,
+  BalanceToken,
+  OrderedBalancesOptions,
+  TokenBalance,
+} from "./types/bridge";
 
 // Agent-wallet (Modular Agent Address) types
 export type {

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -131,3 +131,52 @@ export interface BridgeHistory {
    */
   external_block_height: number | null;
 }
+
+/**
+ * A token whose balance ledger can be ranked by get_ordered_balances (migration 053).
+ *
+ * The node resolves each name to a bridge's reward_id and rejects anything else, so this union is
+ * the complete set.
+ */
+export type BalanceToken = "TRUF" | "USDC";
+
+/** Options for reading a token's wallet balances in balance order (the "richlist"). */
+export interface OrderedBalancesOptions {
+  /** Which token's balance ledger to rank. */
+  token: BalanceToken;
+  /** Smallest balance first when true. Defaults to false (largest first). */
+  ascending?: boolean;
+  /**
+   * How many wallets to return. Defaults to 20.
+   *
+   * The node clamps this to a hard maximum of 50 — asking for more returns 50 rather than failing.
+   * The cap is deliberately not re-checked here, so it stays owned in one place.
+   */
+  limit?: number;
+  /**
+   * Only include wallets at or above this balance, in token base units. Defaults to no threshold.
+   *
+   * A string for the same reason balances are returned as strings — see TokenBalance.balance.
+   */
+  minBalance?: string;
+}
+
+/** One wallet's balance, as returned by get_ordered_balances (migration 053). */
+export interface TokenBalance {
+  /** The wallet, as a 0x-prefixed lowercase hex address. */
+  address: string;
+  /**
+   * The balance in token base units (18 decimals for TRUF, 6 for USDC).
+   *
+   * A string, not a number: real TRUF balances run to 24 digits, well past
+   * Number.MAX_SAFE_INTEGER (~9.0e15), so a numeric representation would silently drop the
+   * low-order digits.
+   */
+  balance: string;
+}
+
+/** @internal Raw row from get_ordered_balances (migration 053) */
+export interface RawTokenBalance {
+  address: string;
+  balance: string;
+}


### PR DESCRIPTION
Exposes the node's `get_ordered_balances` action (migration 053) to JavaScript, so a caller can rank a token's holders — the data layer behind the Trufscan richlist.

- resolves: <https://github.com/trufnetwork/sdk-js/issues/166>
- <https://github.com/trufnetwork/trufscan/issues/144>

The node action is already merged and live on mainnet; this was the missing JavaScript half.

```typescript
// The 10 largest TRUF holders
const top = await client.getOrderedBalances({ token: "TRUF", limit: 10 });

// The smallest USDC holders still holding at least 1 USDC
const small = await client.getOrderedBalances({
  token: "USDC",
  ascending: true,
  minBalance: "1000000",
});
```

## What is here

`getOrderedBalances` on `Action`, beside the existing `getWalletBalance`, with a passthrough on the client. It sits there because it reads the same erc20 balance ledger — `getWalletBalance` reads one wallet, this ranks them all.

`Action.call` gains an optional `types` parameter. It is additive and existing callers are untouched.

## Decisions worth reviewing

**Balances are strings, never numbers.** A real mainnet TRUF balance such as `685701000000000000000000` is 24 digits, well past `Number.MAX_SAFE_INTEGER`. Verified against live mainnet rather than assumed: round-tripping the top holder's balance through `Number()` does not reproduce it. This matches the existing convention for `vaultBalance` and `getWalletBalance`.

**All four parameters are always sent, including the ones the node would default.** kwil-js resolves named parameters positionally, so omitting a middle one shifts later arguments into the wrong slots — supplying only `{$token, $limit}` fails with `expected argument 2 to be of type bool, but got int8`, because the limit lands in the sort-direction slot. Supplying explicit types does not change this. The defaults therefore mirror migration 053 and a test pins them, so a node-side change surfaces as a failure rather than silent drift.

**`$min_balance` carries an explicit `Numeric(78, 0)` type.** Without it the node rejects the value as text. Same pattern as `maaActions.ts` for `$fee_flat`.

**An unsupported token is rejected before the call goes out.** This one is worth a look, because it is defending against something surprising: kwil-js reports the node's own `ERROR` as an empty `200`. Calling with an unknown token returns `{"status": 200, "data": {"result": [], "logs": ""}}` — no error field anywhere — which is indistinguishable from a token that simply has no holders. `kwil-cli` against the same endpoint prints the error correctly, so this is client-layer behaviour. Validating the token locally is what keeps a typo from looking like an empty richlist.

**An empty result is `[]`, not an error**, unlike `getWalletBalance` which throws on zero rows. For a richlist, "no wallet clears your threshold" is a legitimate answer.

**The limit cap is not re-implemented here.** The node clamps to 50; duplicating that constant client-side would drift the moment the node changes it. It is documented instead.

## Testing

Eight unit tests in `action.test.ts` against a mocked client, covering the call shape, row mapping, the pinned defaults, the numeric typing, parameter forwarding, token rejection, empty results, and non-200 handling. Full suite is 308 green; typecheck and build clean.

Also verified against live mainnet with the real method, not mocks: descending TRUF matches the node baseline, ordering holds, USDC ascending with a threshold filters correctly, an impossible threshold returns `[]` without throwing, and an unsupported token throws.

Two things unit tests here cannot cover, both intentional:

- **The hard cap of 50 is not verified end-to-end.** Mainnet has 24 TRUF and 12 USDC holders, so a `limit: 100` request returns 24 and the clamp never engages. It is covered node-side in `tests/streams/order_book/richlist_test.go`.
- On-chain behaviour generally is the node's test surface; this layer only forwards the call and maps rows.

## Follow-ups, not in this PR

- `getPositionsByWallet` and `getCollateralByWallet` (#162) are missing from `docs/api-reference.md`, though the surface around them is documented.
- sdk-go has an unmerged branch for the same feature, and sdk-py wraps sdk-go, so it is blocked behind that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an ordered token-balance lookup for TRUF and USDC.
  * View token holders ranked by balance in ascending or descending order.
  * Filter results by maximum count and minimum balance.
  * Balances are returned as precise strings in token base units.
  * Added public types and client access for ordered balance queries.

* **Documentation**
  * Added API reference details and usage examples, including balance formatting and handling unsupported tokens or empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->