### PR TITLE
feat: read a wallet's fee ledger in one call

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -576,12 +576,12 @@ Lists transactions filtered by wallet address and mode, with pagination support.
 #### Parameters
 - `input: Object`
   - `wallet: string` - Ethereum address to query (required)
-  - `mode: 'paid' | 'received' | 'both'` - Filter mode:
+  - `mode?: 'paid' | 'received' | 'both'` - Filter mode (optional, default: `'paid'`):
     - `'paid'` - Transactions where wallet paid fees
     - `'received'` - Transactions where wallet received fee distributions
     - `'both'` - All transactions involving the wallet
-  - `limit?: number` - Maximum results to return (optional, default: 20, max: 1000)
-  - `offset?: number` - Pagination offset (optional, default: 0)
+  - `limit?: number` - Maximum **transactions** to return (optional, default: 20; the node errors above 1000). The node paginates before expanding each transaction into one row per fee distribution, so the returned array can be longer than this.
+  - `offset?: number` - Transactions to skip, for pagination (optional, default: 0)
 
 #### Returns
 - `Promise<TransactionFeeEntry[]>` - Array of transaction entries, each containing:
@@ -601,7 +601,7 @@ Lists transactions filtered by wallet address and mode, with pagination support.
 #### Example - List Fees Paid
 ```typescript
 const transactionAction = client.loadTransactionAction();
-const wallet = client.address;
+const wallet = client.address().getAddress();
 
 const entries = await transactionAction.listTransactionFees({
   wallet,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -112,14 +112,20 @@ export abstract class BaseTNClient<T extends EnvironmentType> {
 
   /**
    * Returns the Kwil client used by the client.
-   * @returns An instance of Kwil.
+   *
+   * Typed as the concrete client rather than the abstract `Kwil` base, because
+   * `call` and `execute` are declared on `NodeKwil`/`WebKwil` — the base only has a
+   * protected `baseCall`. Returning the base made callers cast to reach an action
+   * the SDK does not wrap yet.
+   *
+   * @returns The environment's Kwil client.
    * @throws If the Kwil client is not initialized.
    */
-  getKwilClient(): Types.Kwil<EnvironmentType> {
+  getKwilClient(): NodeKwil | WebKwil {
     if (!this.kwilClient) {
       throw new Error("Kwil client not initialized");
     }
-    return this.kwilClient;
+    return this.kwilClient as NodeKwil | WebKwil;
   }
 
   /**

--- a/src/contracts-api/action.test.ts
+++ b/src/contracts-api/action.test.ts
@@ -17,6 +17,69 @@ describe("Action", () => {
         signatureType: "secp256k1_ep",
     } as unknown as KwilSigner;
 
+    it("coerces INT8 columns the node sends as strings into the declared numbers", async () => {
+        // block_height / block_timestamp are INT8, which arrives as a string over the
+        // wire even though BridgeHistory declares them as number. A real mainnet row.
+        const action = new Action(mockKwil, mockSigner);
+        const callSpy = vi.spyOn(action as any, "call");
+
+        callSpy.mockResolvedValue(
+            Either.right([
+                {
+                    type: "transfer",
+                    amount: "1000000000000000000",
+                    from_address: "RxCo2PDYRdoRAIaBKjLebZDX/1w=",
+                    to_address: "6J6yEsTbzpV23sLPB51+RYCmCpE=",
+                    internal_tx_hash: "/qipiretMAD0LqJOijtZ5pOzPvvBP4xYqU/NYaoeqFY=",
+                    external_tx_hash: null,
+                    status: "completed",
+                    block_height: "1954099",
+                    block_timestamp: "1784644272",
+                    external_block_height: null,
+                } as unknown as BridgeHistory,
+            ])
+        );
+
+        const [row] = await action.getHistory("eth_truf", "0x123", 1, 0);
+
+        expect(row.block_height).toBe(1954099);
+        expect(row.block_timestamp).toBe(1784644272);
+        expect(typeof row.block_height).toBe("number");
+        expect(typeof row.block_timestamp).toBe("number");
+        // A null external height stays null rather than becoming 0.
+        expect(row.external_block_height).toBeNull();
+        // NUMERIC amounts must NOT be coerced; precision would be lost.
+        expect(row.amount).toBe("1000000000000000000");
+    });
+
+    it("leaves numeric INT8 values untouched", async () => {
+        const action = new Action(mockKwil, mockSigner);
+        const callSpy = vi.spyOn(action as any, "call");
+
+        callSpy.mockResolvedValue(
+            Either.right([
+                {
+                    type: "deposit",
+                    amount: "100",
+                    from_address: null,
+                    to_address: "0x123",
+                    internal_tx_hash: null,
+                    external_tx_hash: "0xabc",
+                    status: "completed",
+                    block_height: 10,
+                    block_timestamp: 1000,
+                    external_block_height: 5,
+                } as BridgeHistory,
+            ])
+        );
+
+        const [row] = await action.getHistory("sepolia_bridge", "0x123", 1, 0);
+
+        expect(row.block_height).toBe(10);
+        expect(row.block_timestamp).toBe(1000);
+        expect(row.external_block_height).toBe(5);
+    });
+
     it("should call get_history with correct parameters", async () => {
         const action = new Action(mockKwil, mockSigner);
         

--- a/src/contracts-api/action.ts
+++ b/src/contracts-api/action.ts
@@ -1357,9 +1357,22 @@ export class Action {
       }
     );
 
+    // INT8 columns arrive as strings over the wire, so coerce them to match the
+    // numbers BridgeHistory declares. Heights and unix seconds fit a JS number.
+    const toNumber = (value: unknown): number =>
+      typeof value === "number" ? value : Number(value);
+
     return result
       .mapRight((rows) => {
-        return rows || [];
+        return (rows || []).map((row) => ({
+          ...row,
+          block_height: toNumber(row.block_height),
+          block_timestamp: toNumber(row.block_timestamp),
+          external_block_height:
+            row.external_block_height === null || row.external_block_height === undefined
+              ? null
+              : toNumber(row.external_block_height),
+        }));
       })
       .throw();
   }

--- a/src/contracts-api/transactionAction.test.ts
+++ b/src/contracts-api/transactionAction.test.ts
@@ -113,3 +113,162 @@ describe("TransactionAction.getTransactionInput", () => {
     );
   });
 });
+
+/**
+ * Unit tests for listTransactionFees. The node action (migration 027) is the canonical
+ * source of the query semantics; this layer only forwards the parameters and maps rows,
+ * so the kwil client is mocked. Row values mirror a real mainnet response: INT8 columns
+ * arrive as strings, and NUMERIC(78, 0) amounts must survive as strings.
+ */
+
+/** A real mainnet fee row, with the wire types the node actually sends. */
+const feeRow = {
+  tx_id: "0xfd6e1e210b855d27e278500f23de2880cbe21e70e854a0c79c1d8878b7d1f206",
+  block_height: "1954022",
+  method: "insertRecords",
+  caller: "0x4710a8d8f0d845da110086812a32de6d90d7ff5c",
+  total_fee: "1000000000000000000",
+  fee_recipient: "0xe89eb212c4dbce9576dec2cf079d7e4580a60a91",
+  metadata: null,
+  distribution_sequence: 1,
+  distribution_recipient: "0xe89eb212c4dbce9576dec2cf079d7e4580a60a91",
+  distribution_amount: "1000000000000000000",
+};
+
+function makeFeeAction(call: ReturnType<typeof vi.fn>) {
+  const mockKwil = { call } as unknown as NodeKwil;
+  return new TransactionAction(mockKwil, mockSigner);
+}
+
+const okRows = (rows: unknown[]) => ({ status: 200, data: { result: rows } });
+
+describe("TransactionAction.listTransactionFees", () => {
+  it("calls list_transaction_fees and maps a row to camelCase", async () => {
+    const call = vi.fn().mockResolvedValue(okRows([feeRow]));
+    const action = makeFeeAction(call);
+
+    const entries = await action.listTransactionFees({ wallet: feeRow.caller });
+
+    expect(call.mock.calls[0][0]).toMatchObject({
+      namespace: "main",
+      name: "list_transaction_fees",
+    });
+    expect(entries).toEqual([
+      {
+        txId: feeRow.tx_id,
+        blockHeight: 1954022,
+        method: "insertRecords",
+        caller: feeRow.caller,
+        totalFee: "1000000000000000000",
+        feeRecipient: feeRow.fee_recipient,
+        distributionSequence: 1,
+        distributionRecipient: feeRow.distribution_recipient,
+        distributionAmount: "1000000000000000000",
+      },
+    ]);
+  });
+
+  it("defaults mode to paid and pins the node's other defaults", async () => {
+    const call = vi.fn().mockResolvedValue(okRows([]));
+    const action = makeFeeAction(call);
+
+    await action.listTransactionFees({ wallet: feeRow.caller });
+
+    expect(call.mock.calls[0][0].inputs).toEqual({
+      $wallet: feeRow.caller,
+      $mode: "paid",
+      $limit: 20,
+      $offset: 0,
+    });
+  });
+
+  it("forwards mode, limit, and offset", async () => {
+    const call = vi.fn().mockResolvedValue(okRows([]));
+    const action = makeFeeAction(call);
+
+    await action.listTransactionFees({
+      wallet: feeRow.caller,
+      mode: "both",
+      limit: 200,
+      offset: 40,
+    });
+
+    expect(call.mock.calls[0][0].inputs).toEqual({
+      $wallet: feeRow.caller,
+      $mode: "both",
+      $limit: 200,
+      $offset: 40,
+    });
+  });
+
+  it("keeps fee amounts as strings so 18-decimal precision survives", async () => {
+    // 78-digit NUMERIC is far past Number.MAX_SAFE_INTEGER; Number() would corrupt it.
+    const big = "685701000000000000000000";
+    const call = vi.fn().mockResolvedValue(
+      okRows([{ ...feeRow, total_fee: big, distribution_amount: big }])
+    );
+    const action = makeFeeAction(call);
+
+    const [entry] = await action.listTransactionFees({ wallet: feeRow.caller });
+
+    expect(entry.totalFee).toBe(big);
+    expect(entry.distributionAmount).toBe(big);
+    expect(String(Number(big))).not.toBe(big);
+  });
+
+  it("converts the INT8 block height to a number", async () => {
+    const call = vi.fn().mockResolvedValue(okRows([feeRow]));
+    const action = makeFeeAction(call);
+
+    const [entry] = await action.listTransactionFees({ wallet: feeRow.caller });
+
+    expect(entry.blockHeight).toBe(1954022);
+    expect(typeof entry.blockHeight).toBe("number");
+  });
+
+  it("omits optional fields the node returned as null", async () => {
+    const call = vi.fn().mockResolvedValue(
+      okRows([
+        {
+          ...feeRow,
+          fee_recipient: null,
+          metadata: null,
+          distribution_recipient: null,
+          distribution_amount: null,
+        },
+      ])
+    );
+    const action = makeFeeAction(call);
+
+    const [entry] = await action.listTransactionFees({ wallet: feeRow.caller });
+
+    expect(entry).not.toHaveProperty("feeRecipient");
+    expect(entry).not.toHaveProperty("metadata");
+    expect(entry).not.toHaveProperty("distributionRecipient");
+    expect(entry).not.toHaveProperty("distributionAmount");
+  });
+
+  it("returns an empty array when the wallet has no fee rows", async () => {
+    const call = vi.fn().mockResolvedValue(okRows([]));
+    const action = makeFeeAction(call);
+
+    await expect(action.listTransactionFees({ wallet: feeRow.caller })).resolves.toEqual([]);
+  });
+
+  it("rejects an empty wallet before calling the node", async () => {
+    const call = vi.fn();
+    const action = makeFeeAction(call);
+
+    await expect(action.listTransactionFees({ wallet: "   " })).rejects.toThrow(/wallet is required/);
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  it("throws on a non-200 response", async () => {
+    const call = vi.fn().mockResolvedValue({ status: 500, data: undefined });
+    const action = makeFeeAction(call);
+
+    await expect(action.listTransactionFees({ wallet: feeRow.caller })).rejects.toThrow(
+      /Failed to list transaction fees: HTTP 500/
+    );
+  });
+});

--- a/src/contracts-api/transactionAction.ts
+++ b/src/contracts-api/transactionAction.ts
@@ -1,5 +1,11 @@
 import { KwilSigner, NodeKwil, WebKwil } from "@trufnetwork/kwil-js";
-import { TransactionEvent, FeeDistribution, GetTransactionEventInput } from "../types/transaction";
+import {
+  TransactionEvent,
+  FeeDistribution,
+  GetTransactionEventInput,
+  ListTransactionFeesInput,
+  TransactionFeeEntry,
+} from "../types/transaction";
 import { decodeTransactionPayload } from "../util/TransactionPayload";
 import type { DecodedTransactionPayload } from "../util/TransactionPayload";
 import { resolveBlockStamps } from "../util/blockStamps";
@@ -31,6 +37,22 @@ interface TransactionEventRow {
   fee_recipient?: string | null;
   metadata?: string | null;
   fee_distributions: string;
+}
+
+/**
+ * Database row structure returned from list_transaction_fees action
+ */
+interface TransactionFeeRow {
+  tx_id: string;
+  block_height: string | number;
+  method: string;
+  caller: string;
+  total_fee: string | number;
+  fee_recipient?: string | null;
+  metadata?: string | null;
+  distribution_sequence?: string | number | null;
+  distribution_recipient?: string | null;
+  distribution_amount?: string | number | null;
 }
 
 /**
@@ -168,6 +190,93 @@ export class TransactionAction {
       metadata: row.metadata || undefined,
       feeDistributions,
     };
+  }
+
+  /**
+   * Lists a wallet's fee-ledger entries in one call, instead of one
+   * {@link getTransactionEvent} call per transaction hash.
+   *
+   * The node returns one row per fee distribution, so a transaction with several
+   * distributions appears more than once. Group by `txId` to reassemble it.
+   *
+   * `limit` and `offset` count transactions rather than rows, because the node
+   * paginates before expanding the distributions — so the array can be longer than
+   * `limit`.
+   *
+   * @param input Wallet, match mode, and pagination
+   * @returns Promise resolving to the ledger rows, empty when the wallet has none
+   * @throws Error if the wallet is missing or the query fails
+   *
+   * @example
+   * ```typescript
+   * const txAction = client.loadTransactionAction();
+   * const entries = await txAction.listTransactionFees({
+   *   wallet: client.address().getAddress(),
+   *   mode: "both",
+   *   limit: 200,
+   * });
+   *
+   * // Collect every distribution, rather than letting later rows overwrite earlier ones.
+   * const rowsByTx = new Map<string, TransactionFeeEntry[]>();
+   * for (const entry of entries) {
+   *   const existing = rowsByTx.get(entry.txId) ?? [];
+   *   existing.push(entry);
+   *   rowsByTx.set(entry.txId, existing);
+   * }
+   * ```
+   */
+  async listTransactionFees(input: ListTransactionFeesInput): Promise<TransactionFeeEntry[]> {
+    if (!input.wallet || input.wallet.trim() === "") {
+      throw new Error("wallet is required");
+    }
+
+    const result = await this.kwilClient.call(
+      {
+        namespace: "main",
+        name: "list_transaction_fees",
+        inputs: {
+          $wallet: input.wallet,
+          $mode: input.mode ?? "paid",
+          $limit: input.limit ?? 20,
+          $offset: input.offset ?? 0,
+        },
+      },
+      this.kwilSigner
+    );
+
+    if (result.status !== 200) {
+      throw new Error(`Failed to list transaction fees: HTTP ${result.status}`);
+    }
+
+    const rows = (result.data?.result ?? []) as TransactionFeeRow[];
+
+    return rows.map((row) => {
+      // INT8 arrives as a string over the wire; block heights and sequences are
+      // small enough to hold in a number, unlike the NUMERIC fee amounts.
+      const blockHeight =
+        typeof row.block_height === "number" ? row.block_height : parseInt(row.block_height, 10);
+      if (!Number.isFinite(blockHeight) || blockHeight < 0) {
+        throw new Error(`Invalid block height: ${row.block_height} (tx: ${row.tx_id})`);
+      }
+
+      const entry: TransactionFeeEntry = {
+        txId: row.tx_id,
+        blockHeight,
+        method: row.method,
+        caller: row.caller,
+        totalFee: String(row.total_fee ?? "0"),
+        distributionSequence: Number(row.distribution_sequence ?? 0),
+      };
+
+      if (row.fee_recipient) entry.feeRecipient = row.fee_recipient;
+      if (row.metadata) entry.metadata = row.metadata;
+      if (row.distribution_recipient) entry.distributionRecipient = row.distribution_recipient;
+      if (row.distribution_amount !== null && row.distribution_amount !== undefined) {
+        entry.distributionAmount = String(row.distribution_amount);
+      }
+
+      return entry;
+    });
   }
 
   /**

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -14,6 +14,7 @@ export { ComposedAction } from "./contracts-api/composedAction";
 export { RoleManagement } from "./contracts-api/roleManagement";
 export { AttestationAction } from "./contracts-api/attestationAction";
 export { OrderbookAction } from "./contracts-api/orderbookAction";
+export { TransactionAction } from "./contracts-api/transactionAction";
 export { MAAAction } from "./contracts-api/maaActions";
 export { deployStream } from "./contracts-api/deployStream";
 export { deleteStream } from "./contracts-api/deleteStream";
@@ -90,10 +91,22 @@ export type {
 // Bridge types
 export type {
   WithdrawalProof,
+  BridgeHistory,
   BalanceToken,
   OrderedBalancesOptions,
   TokenBalance,
 } from "./types/bridge";
+
+// Transaction ledger types
+export type {
+  LastTransaction,
+  FeeDistribution,
+  TransactionEvent,
+  GetTransactionEventInput,
+  TransactionFeeMode,
+  ListTransactionFeesInput,
+  TransactionFeeEntry,
+} from "./types/transaction";
 
 // Agent-wallet (Modular Agent Address) types
 export type {

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -80,3 +80,64 @@ export interface GetTransactionEventInput {
     /** Transaction hash (with or without 0x prefix) */
     txId: string;
 }
+
+/**
+ * Which side of the fee ledger to match a wallet against.
+ *
+ * - `paid` - the wallet was the transaction's caller
+ * - `received` - the wallet was the fee recipient or a distribution recipient
+ * - `both` - either of the above
+ *
+ * `paid` matches on the caller alone, so it omits transactions where the wallet
+ * received a distribution without sending the transaction. Use `both` to see those.
+ */
+export type TransactionFeeMode = "paid" | "received" | "both";
+
+/**
+ * Input for listing a wallet's transaction fees
+ */
+export interface ListTransactionFeesInput {
+    /** Ethereum address to query */
+    wallet: string;
+    /** Which side of the ledger to match. Defaults to "paid" (the node's default). */
+    mode?: TransactionFeeMode;
+    /**
+     * Maximum *transactions* to return, not rows. The node applies the limit before
+     * expanding each transaction into one row per fee distribution, so the returned
+     * array can be longer than this. Defaults to 20; the node errors above 1000, and
+     * treats a value of zero or less as 20.
+     */
+    limit?: number;
+    /** Transactions to skip, for pagination. Defaults to 0. */
+    offset?: number;
+}
+
+/**
+ * One row of the fee ledger.
+ *
+ * The node returns one row per fee distribution, so a transaction with several
+ * distributions appears more than once, distinguished by `distributionSequence`.
+ * Group by `txId` to reassemble a whole transaction.
+ */
+export interface TransactionFeeEntry {
+    /** Transaction hash (0x-prefixed) */
+    txId: string;
+    /** Block height when the transaction was included */
+    blockHeight: number;
+    /** Method name (e.g., "insertRecords") */
+    method: string;
+    /** Ethereum address of the caller (lowercase, 0x-prefixed) */
+    caller: string;
+    /** Total fee for the transaction, as a string to preserve 18-decimal precision */
+    totalFee: string;
+    /** Primary fee recipient, when the node recorded one */
+    feeRecipient?: string;
+    /** Optional metadata JSON */
+    metadata?: string;
+    /** Index of this distribution within the transaction */
+    distributionSequence: number;
+    /** Recipient for this distribution */
+    distributionRecipient?: string;
+    /** Amount for this distribution, as a string to preserve precision */
+    distributionAmount?: string;
+}


### PR DESCRIPTION
Wraps the node's `list_transaction_fees` action, so a caller can read a wallet's whole fee ledger in one request instead of one `getTransactionEvent` call per transaction hash.

- <https://github.com/trufnetwork/truf-network/pull/1391#issuecomment-5034069035>

The TN Account UI was making roughly 400 requests to render one page of transaction history, one `getTransactionEvent` per row. This is the batch read that replaces them.

```typescript
const txAction = client.loadTransactionAction();
const entries = await txAction.listTransactionFees({
  wallet,
  mode: "both",
  limit: 200,
});
```

## What is here

**`listTransactionFees` on `TransactionAction`.** The method was already described in `docs/api-reference.md` and named in the architecture notes, but had never been implemented, so following the docs threw a `TypeError`. It now exists and matches the documented contract.

**`getKwilClient()` returns the concrete client.** It was declared as the abstract `Types.Kwil<EnvironmentType>`, which only carries a protected `baseCall`; `call` and `execute` are declared on `NodeKwil`/`WebKwil`. Reaching an unwrapped action therefore needed `as any`. Confirmed by reverting the signature: the old one produces `TS2339: Property 'call' does not exist on type 'Kwil<EnvironmentType>'`, the new one compiles.

**`getHistory` returns the numbers its type promises.** `block_height` and `block_timestamp` are INT8, which arrives as a string, while `BridgeHistory` declares them `number`. Corrected in the mapper rather than the type, so no consumer has to change and any existing arithmetic on those fields starts working.

`TransactionAction` and `BridgeHistory` are now exported from `internal.ts`. Both were unreachable from the package entrypoints.

## Breaking change, narrow

Narrowing `getKwilClient()` is safe for callers: assigning to a `Types.Kwil<EnvironmentType>` variable, passing to a base-typed parameter, and calling `.call<T>()` all still compile. It is not safe for a subclass that **overrides** `getKwilClient()` with the old abstract return type, which now fails with `TS2416`. No subclass in this repo overrides it; `NodeTNClient` and `BrowserTNClient` set `this.kwilClient` in their constructors instead.

## Worth reviewing

**`limit` and `offset` count transactions, not rows.** The node applies them inside the sub-select over `transaction_events`, before the `LEFT JOIN` that expands each transaction into one row per fee distribution, so the returned array can be longer than `limit`. The docs said "results"; corrected. The node also errors above 1000 rather than clamping.

**Amounts stay strings.** `total_fee` and `distribution_amount` are `NUMERIC(78, 0)`. `blockHeight` and `distributionSequence` become numbers, which they fit.

## Testing

11 unit tests across `transactionAction.test.ts` and `action.test.ts`, covering the call shape, camelCase mapping, pinned defaults, parameter forwarding, precision, INT8 coercion in both string and numeric forms, null handling, empty results, and non-200 responses. Full suite 256 green; typecheck and build clean.

Verified against live mainnet rather than only mocks: `listTransactionFees` returns real ledger rows, `getKwilClient().call` works with no cast, and `getHistory` returns numeric heights.

Also corrected in `docs/api-reference.md`: `mode` was documented as required though the node defaults it to `paid`, and an example read `client.address` where `address()` is a method.
