### PR TITLE
feat: join and fund an agent wallet in one call

### DIFF
--- a/examples/maa_join_and_fund_example/.env.example
+++ b/examples/maa_join_and_fund_example/.env.example
@@ -1,0 +1,35 @@
+# Atomic MAA activation smoke test — configuration.
+#
+# Copy this file to `.env` (same directory) and fill in the two private keys:
+#
+#     cp .env.example .env
+#
+# `.env` is gitignored. Real environment variables take precedence over `.env`,
+# so you can still override any value with a shell export.
+
+# --- required: two DISTINCT keys -------------------------------------------------
+# Both accept the key with OR without a 0x prefix.
+# AGENT = the restricted agent (signs the rule).
+# OWNER = the unrestricted owner/funder (joins + funds; must already hold MAA_FUND_AMOUNT
+#         of the funding bridge token on TN).
+AGENT_PRIVATE_KEY=
+OWNER_PRIVATE_KEY=
+
+# --- network -------------------------------------------------------------------
+# The testnet RPC/gateway endpoint. The chain id is auto-discovered from it.
+# Requires the on-chain maa_join_and_fund action (node migration 054) on this network.
+PROVIDER_URL=https://gateway.testnet.truf.network
+
+# --- token / funding -----------------------------------------------------------
+# Bridge namespace used to fund the wallet (dev/testnet: hoodi_tt).
+MAA_BRIDGE=hoodi_tt
+# Amount to fund the wallet with, in base units (a positive base-10 integer that fits
+# NUMERIC(78,0)). Default is 10 tokens. The owner must already hold at least this much.
+MAA_FUND_AMOUNT=10000000000000000000
+# Owner-withdraw commission paid to the agent, in basis points (250 = 2.5%).
+MAA_FEE_BPS=250
+
+# --- reproducibility (optional) ------------------------------------------------
+# Pin a 32-byte salt (64 hex chars, optional 0x) for a reproducible rule_id across
+# runs. Leave unset for a fresh salt per run (a new rule/wallet each time).
+# MAA_SALT=

--- a/examples/maa_join_and_fund_example/README.md
+++ b/examples/maa_join_and_fund_example/README.md
@@ -1,0 +1,55 @@
+# Atomic MAA activation — join + fund in one transaction (JavaScript / TypeScript)
+
+A runnable, end-to-end smoke test of `joinAndFundAgentAddress` through the JS/TS SDK, against a live
+TRUF.NETWORK node. It joins a rule and funds the derived agent wallet in a **single** transaction,
+then proves both legs committed together.
+
+For the broader agent-wallet lifecycle (create → join → fund → operate → withdraw, with the two-step
+funding), see [`../maa_lifecycle_example`](../maa_lifecycle_example). This example is focused on the
+one-call atomic activation.
+
+## What it proves
+
+1. **One transaction, both legs** — `joinAndFundAgentAddress` returns a single tx hash that covers the
+   join and the funding transfer.
+2. **The join committed** — after that one tx, the derived wallet is a registered instance
+   (`maa_is_known` is true).
+3. **The funding committed** — the wallet's escrow holds exactly the funded amount, and the owner's
+   balance dropped by exactly that amount.
+4. **The wallet is immediately usable** — the owner withdraws the escrow back out (paying the agent
+   its commission), so the run leaves nothing stranded.
+
+Atomicity means these never disagree: you can't end up joined-but-unfunded or funded-but-unregistered.
+
+## Requirements
+
+- The on-chain `maa_join_and_fund` action (node migration **054**) deployed on the target network.
+- Two **distinct** keys. The **owner** must already hold at least `MAA_FUND_AMOUNT` of the funding
+  bridge token (`hoodi_tt` on dev/testnet) on TN — bringing tokens in from L1 is a separate bridge
+  deposit, not part of this call.
+
+## Run
+
+```bash
+# from the repo root: build @trufnetwork/sdk-js so the local dependency resolves
+npm install && npm run build
+
+cd examples/maa_join_and_fund_example
+cp .env.example .env        # fill in AGENT_PRIVATE_KEY and OWNER_PRIVATE_KEY
+npm install
+npm start
+```
+
+See [`.env.example`](./.env.example) for every setting.
+
+## What success looks like
+
+Each step prints a `✅`, the wallet's escrow equals the funded amount after a single tx, the owner's
+balance drops by exactly that amount, the withdrawal drains the escrow, and the run ends with
+`✅ atomic join + fund smoke test PASSED`. A non-zero exit or a missing `✅` means a step failed.
+
+## Source of truth
+
+The on-chain action is `internal/migrations/054-maa-join-fund.sql` in `trufnetwork/node`; the node
+integration tests are `tests/streams/maa/join_and_fund_test.go` (happy path, validation, atomicity,
+duplicate join). The SDK method is `MAAAction.joinAndFundAgentAddress`.

--- a/examples/maa_join_and_fund_example/main.ts
+++ b/examples/maa_join_and_fund_example/main.ts
@@ -1,0 +1,288 @@
+/**
+ * Atomic MAA activation smoke test — join + fund in one transaction (JavaScript/TypeScript SDK).
+ *
+ * The general agent-wallet flow joins a rule and then funds the derived wallet in two separate
+ * transactions (see ../maa_lifecycle_example). This program exercises the one-call alternative,
+ * joinAndFundAgentAddress, which does both in a SINGLE on-chain transaction: either the join and the
+ * funding transfer both commit, or neither does. It proves, end-to-end through @trufnetwork/sdk-js,
+ * against a live TRUF.NETWORK node:
+ *
+ *   - a restricted AGENT key registers an immutable rule (fund-free);
+ *   - an unrestricted OWNER key joins that rule AND funds the derived wallet in ONE transaction —
+ *     one tx hash covers both legs;
+ *   - after that single tx: the wallet is registered (the join committed) AND holds exactly the
+ *     funding amount, which was debited from the owner (the transfer committed) — atomicity proven;
+ *   - the funded wallet is immediately usable: the owner withdraws it back out, draining the escrow.
+ *
+ * Requires the on-chain maa_join_and_fund action (node migration 054) on the target network.
+ *
+ * Config comes from a .env file next to this program (real environment variables take precedence).
+ * Two DISTINCT keys are required — the agent and the owner are different identities. The OWNER must
+ * hold at least MAA_FUND_AMOUNT of the funding bridge token on TN.
+ *
+ *     cd examples/maa_join_and_fund_example
+ *     cp .env.example .env        # then fill in AGENT_PRIVATE_KEY and OWNER_PRIVATE_KEY
+ *     npm install
+ *     npm start
+ *
+ * See .env.example for every setting, and README.md for what success looks like.
+ */
+
+import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { MAAAddress, NodeTNClient } from "@trufnetwork/sdk-js";
+import { Utils } from "@trufnetwork/kwil-js";
+import { getBytes, Wallet } from "ethers";
+
+// Bridge amounts are NUMERIC(78,0); pin maa_withdraw's $amount with this EXACT precision/scale.
+const TOKEN_PRECISION = 78;
+const TOKEN_SCALE = 0;
+
+// How long to wait for each transaction to be included before treating it as failed.
+const TX_TIMEOUT_MS = 30_000;
+
+async function run(): Promise<void> {
+  // --- load .env (zero-dependency; real environment variables take precedence) ---
+  const here = dirname(fileURLToPath(import.meta.url));
+  loadDotenv(join(process.cwd(), ".env"));
+  loadDotenv(join(here, ".env")); // also look next to this source file; the cwd .env, loaded first, wins
+
+  // --- configuration (all overridable via environment / .env; see .env.example) ---
+  const providerURL = process.env.PROVIDER_URL || "https://gateway.testnet.truf.network";
+  const agentKey = process.env.AGENT_PRIVATE_KEY; // restricted agent (creates the rule)
+  const ownerKey = process.env.OWNER_PRIVATE_KEY; // unrestricted owner / funder
+  const bridge = process.env.MAA_BRIDGE || "hoodi_tt"; // funding bridge namespace
+  const fundAmount = process.env.MAA_FUND_AMOUNT || "10000000000000000000"; // 10 tokens (base units)
+  const feeBps = parseInt(process.env.MAA_FEE_BPS || "250", 10); // owner-withdraw commission to the agent
+
+  if (!agentKey || !ownerKey) {
+    throw new Error(
+      "AGENT_PRIVATE_KEY and OWNER_PRIVATE_KEY must both be set (two distinct keys); see README.md",
+    );
+  }
+  if (!Number.isInteger(feeBps) || feeBps < 0 || feeBps > 10000) {
+    throw new Error(`MAA_FEE_BPS must be an integer between 0 and 10000 (10000 = 100%), got ${feeBps}`);
+  }
+  if (!/^[0-9]{1,78}$/.test(fundAmount) || BigInt(fundAmount) <= 0n) {
+    throw new Error(`MAA_FUND_AMOUNT must be a positive base-10 integer in base units, got ${fundAmount}`);
+  }
+
+  const salt = buildSalt(process.env.MAA_SALT);
+
+  // The rule's allow-list is irrelevant to join+fund; use the data-provision actions for a realistic rule.
+  const namespaces = ["main", "main"];
+  const actions = ["create_streams", "insert_records"];
+  const bodyHashes = [null, null];
+
+  // --- clients & their addresses ---
+  const chainId = await NodeTNClient.getDefaultChainId(providerURL);
+  if (!chainId) {
+    throw new Error(`could not resolve chain id from ${providerURL}`);
+  }
+  const agent = newClient(providerURL, agentKey, chainId);
+  const owner = newClient(providerURL, ownerKey, chainId);
+  const agentMaa = agent.loadMAAAction();
+  const ownerMaa = owner.loadMAAAction();
+
+  const agentHex = agent.address().getAddress();
+  const ownerHex = owner.address().getAddress();
+
+  banner("Atomic MAA activation smoke test (join + fund in one tx)");
+  console.log(`provider : ${providerURL}`);
+  console.log(`bridge   : ${bridge}`);
+  console.log(`agent    : ${agentHex}   (restricted — creates the rule)`);
+  console.log(`owner    : ${ownerHex}   (unrestricted — joins + funds)`);
+  console.log(`fund     : ${fundAmount} (base units)`);
+  if (agentHex.toLowerCase() === ownerHex.toLowerCase()) {
+    throw new Error("agent and owner must be DIFFERENT keys");
+  }
+
+  // The owner must already hold the funding amount on TN (funds from L1 are a separate bridge deposit).
+  const ownerStart = await owner.getWalletBalance(bridge, ownerHex);
+  console.log(`owner ${bridge} balance: ${ownerStart}`);
+  if (BigInt(ownerStart) < BigInt(fundAmount)) {
+    throw new Error(
+      `owner holds ${ownerStart} ${bridge}, needs at least ${fundAmount} to fund the wallet`,
+    );
+  }
+
+  // (a) AGENT creates an immutable rule (fund-free).
+  banner("(a) agent registers the rule");
+  const ruleRes = await agentMaa.createAgentRule({
+    feeMode: "bps",
+    feeBps,
+    feeFlat: "0",
+    namespaces,
+    actions,
+    bodyHashes,
+    salt,
+  });
+  await waitOK(agent, ruleRes.txHash, "create rule");
+  console.log(`✅ rule created: rule_id=${ruleRes.ruleIdHex}  (commission ${(feeBps / 100).toFixed(2)}%)`);
+
+  // (b) OWNER joins AND funds in ONE transaction. This is the whole point: a single tx hash covers
+  //     both the join (registering the wallet) and the funding transfer (owner → wallet).
+  banner("(b) owner joins + funds the wallet — one transaction");
+  const res = await ownerMaa.joinAndFundAgentAddress({
+    ruleId: ruleRes.ruleId,
+    bridge,
+    amount: fundAmount,
+  });
+  const maaHex = res.maaAddressHex;
+  console.log(`join_and_fund tx: ${res.txHash}`);
+  console.log(`agent wallet (MAA): ${maaHex}`);
+
+  // The wallet address is derived locally before the tx even commits — cross-check it.
+  const maaLocal = MAAAddress.deriveMAAAddressHex(ownerHex, agentHex, ruleRes.ruleId);
+  if (maaLocal.toLowerCase() !== maaHex.toLowerCase()) {
+    throw new Error(`local MAA ${maaLocal} != sdk ${maaHex}`);
+  }
+  console.log(`   ↳ matches local derivation ${maaLocal}`);
+
+  await waitOK(owner, res.txHash, "join_and_fund");
+
+  // (c) After that SINGLE tx, prove BOTH legs committed:
+  banner("(c) verify the single tx did both — atomicity");
+
+  //   join leg: the wallet is now a registered instance.
+  const known = await agentMaa.isAgentWallet(res.maaAddress);
+  if (!known) {
+    throw new Error("join leg did not commit: the wallet is not a known instance");
+  }
+  console.log(`✅ join leg committed — maa_is_known: ${known}`);
+
+  //   fund leg: the wallet's escrow holds exactly the funding amount...
+  const escrow = await owner.getWalletBalance(bridge, maaHex);
+  if (escrow !== fundAmount) {
+    throw new Error(`fund leg mismatch: escrow ${escrow}, expected ${fundAmount}`);
+  }
+  console.log(`✅ fund leg committed — wallet escrow: ${escrow}`);
+
+  //   ...and it came out of the owner's balance (debited by exactly the funding amount).
+  const ownerAfter = await owner.getWalletBalance(bridge, ownerHex);
+  const debited = (BigInt(ownerStart) - BigInt(ownerAfter)).toString();
+  if (debited !== fundAmount) {
+    throw new Error(`owner debit mismatch: debited ${debited}, expected ${fundAmount}`);
+  }
+  console.log(`✅ owner debited exactly the funding amount: ${ownerStart} → ${ownerAfter} (−${debited})`);
+
+  //   the join is audited exactly as a plain join would be.
+  const events = await agentMaa.getEvents(ruleRes.ruleId, 100, 0);
+  const joinEvent = events.find((e) => e.eventType === "JOIN");
+  console.log(`   audit: ${events.length} event(s); JOIN recorded: ${joinEvent ? "yes" : "no"}`);
+
+  // (d) The freshly activated wallet is immediately usable — the owner withdraws it back out, paying
+  //     the agent its commission and draining the escrow (so the smoke leaves nothing stranded).
+  banner("(d) owner withdraws the escrow (proves the wallet works; cleans up)");
+  const withdrawTx = await ownerMaa.executeAgentAction({
+    maaAddress: res.maaAddress,
+    action: "maa_withdraw",
+    args: [bridge, escrow],
+    types: [Utils.DataType.Text, Utils.DataType.Numeric(TOKEN_PRECISION, TOKEN_SCALE)],
+  });
+  await waitOK(owner, withdrawTx, "owner withdraw");
+  const drained = await owner.getWalletBalance(bridge, maaHex);
+  if (drained !== "0") {
+    throw new Error(`expected the wallet to be drained, got ${drained}`);
+  }
+  console.log(`✅ owner withdrew ${escrow}; escrow now ${drained}`);
+  console.log(
+    `   ↳ agent earns ~${commission(escrow, feeBps)} (${(feeBps / 100).toFixed(2)}% commission); owner gets the rest`,
+  );
+
+  banner("✅ atomic join + fund smoke test PASSED");
+  console.log("Proven on-chain via the JavaScript SDK:");
+  console.log("  • one transaction both joined the rule and funded the derived wallet");
+  console.log("  • the wallet is registered AND holds exactly the funded amount (both legs committed)");
+  console.log("  • the funding was debited from the owner");
+  console.log("  • the activated wallet is immediately operable (owner withdrew it back out)");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+/** newClient builds a client signing as the given secp256k1 key (with or without 0x). */
+function newClient(endpoint: string, privateKey: string, chainId: string): NodeTNClient {
+  const wallet = new Wallet(privateKey.startsWith("0x") ? privateKey : "0x" + privateKey);
+  return new NodeTNClient({
+    endpoint,
+    signerInfo: { address: wallet.address, signer: wallet },
+    chainId,
+  });
+}
+
+/** waitOK blocks until txHash is included in a block and asserts the transaction succeeded. */
+async function waitOK(client: NodeTNClient, txHash: string, label: string): Promise<void> {
+  try {
+    await client.waitForTx(txHash, TX_TIMEOUT_MS);
+  } catch (e) {
+    throw new Error(`${label}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/**
+ * buildSalt returns the 32-byte rule salt. With MAA_SALT set (64 hex chars, optional 0x) it is pinned
+ * for a reproducible rule_id; otherwise a fresh random salt makes each run register a new rule/MAA, so
+ * re-running never collides with an already-registered rule.
+ */
+function buildSalt(saltHex?: string): Uint8Array {
+  if (saltHex) {
+    const b = getBytes(saltHex.startsWith("0x") ? saltHex : "0x" + saltHex);
+    if (b.length !== 32) {
+      throw new Error(`MAA_SALT must be 32 bytes (64 hex chars), got ${b.length}`);
+    }
+    return b;
+  }
+  const salt = new Uint8Array(32);
+  salt.set(new TextEncoder().encode("MAA"));
+  salt.set(randomBytes(29), 3);
+  return salt;
+}
+
+/**
+ * loadDotenv populates process.env from a KEY=VALUE .env file without overriding existing vars (real
+ * environment variables take precedence). A missing file is a no-op.
+ */
+function loadDotenv(path: string): void {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return; // missing file: nothing to load
+  }
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#") || !line.includes("=")) {
+      continue;
+    }
+    const eq = line.indexOf("=");
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = val;
+    }
+  }
+}
+
+/** commission returns floor(amount * bps / 10000) — a lower bound on the agent's HALF-UP commission. */
+function commission(amount: string, bps: number): string {
+  return ((BigInt(amount) * BigInt(bps)) / 10000n).toString();
+}
+
+function banner(title: string): void {
+  console.log("\n" + "=".repeat(72));
+  console.log(title);
+  console.log("=".repeat(72));
+}
+
+run().catch((err) => {
+  console.error(`❌ ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/examples/maa_join_and_fund_example/package.json
+++ b/examples/maa_join_and_fund_example/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tn-sdk-maa-join-and-fund-example",
+  "version": "1.0.0",
+  "description": "Atomic MAA activation (join + fund in one transaction) smoke test for @trufnetwork/sdk-js",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsx main.ts"
+  },
+  "dependencies": {
+    "@trufnetwork/sdk-js": "file:../..",
+    "@trufnetwork/kwil-js": "0.9.12",
+    "ethers": "^6.13.5",
+    "tsx": "^4.19.1"
+  }
+}

--- a/examples/maa_join_and_fund_example/package.json
+++ b/examples/maa_join_and_fund_example/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@trufnetwork/sdk-js": "file:../..",
-    "@trufnetwork/kwil-js": "0.9.12",
+    "@trufnetwork/kwil-js": "0.9.14",
     "ethers": "^6.13.5",
     "tsx": "^4.19.1"
   }

--- a/examples/maa_lifecycle_example/README.md
+++ b/examples/maa_lifecycle_example/README.md
@@ -37,6 +37,25 @@ The agent and the owner are **different keys**:
 | **Restricted agent** | `AGENT_PRIVATE_KEY` | `createAgentRule`, runs allow-listed actions as the MAA | the `restricted` address baked into `rule_id` |
 | **Unrestricted owner** | `OWNER_PRIVATE_KEY` | `joinAgentAddress`, funds, withdraws | the `unrestricted` address; controls the funds |
 
+## Atomic join + fund (one transaction)
+
+This example funds in two steps — `joinAgentAddress`, then a separate `client.transfer` — which is the
+general flow and the one to use for topping up a wallet that already exists. To activate a **new**
+wallet in a single signed transaction, use `joinAndFundAgentAddress`: it joins the rule and moves the
+funding from the owner's balance into the derived wallet atomically, so a failure can never leave a
+joined-but-unfunded wallet.
+
+```ts
+const { maaAddressHex, txHash } = await ownerMaa.joinAndFundAgentAddress({
+  ruleId,
+  bridge: "eth_truf",              // the bridge the funds are held under
+  amount: "250000000000000000000", // base units; the owner must already hold this on TN
+});
+```
+
+The owner must already hold the funds on TN; bringing tokens in from L1 is a separate bridge deposit.
+Requires the on-chain `maa_join_and_fund` action (node migration 054) on the target network.
+
 ## Run
 
 Configuration is read from a `.env` file next to the program (real environment variables still take

--- a/examples/maa_lifecycle_example/README.md
+++ b/examples/maa_lifecycle_example/README.md
@@ -49,7 +49,7 @@ joined-but-unfunded wallet.
 const { maaAddressHex, txHash } = await ownerMaa.joinAndFundAgentAddress({
   ruleId,
   bridge: "eth_truf",              // the bridge the funds are held under
-  amount: "250000000000000000000", // base units; the owner must already hold this on TN
+  amount: "250000000000000000000", // positive base-10 string in base units, fits NUMERIC(78,0) (≤ 78 digits)
 });
 ```
 

--- a/src/contracts-api/maaActions.test.ts
+++ b/src/contracts-api/maaActions.test.ts
@@ -222,15 +222,25 @@ describe("MAAAction.joinAndFundAgentAddress", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  it("rejects a non-positive or non-integer amount before any call", async () => {
-    for (const amount of ["0", "-1", "1.5", "", "abc"]) {
+  it("rejects a non-string, non-positive, non-integer, or over-78-digit amount before any call", async () => {
+    // A numeric amount (not a string) and a 79-digit string (over NUMERIC(78,0)) must be rejected
+    // locally, alongside the zero/negative/non-integer cases — none may reach getRule or the write.
+    const badAmounts: any[] = ["0", "-1", "1.5", "", "abc", 40, "1".repeat(79)];
+    for (const amount of badAmounts) {
       const { action, call, execute } = makeJoinFundAction();
       await expect(
         action.joinAndFundAgentAddress({ ruleId: ruleIdHex, bridge: "eth_truf", amount }),
-      ).rejects.toThrow("Amount must be greater than 0");
+      ).rejects.toThrow("positive base-10 integer string within NUMERIC(78,0)");
       expect(call).not.toHaveBeenCalled();
       expect(execute).not.toHaveBeenCalled();
     }
+  });
+
+  it("accepts an amount at the NUMERIC(78,0) boundary (78 digits)", async () => {
+    const { action, execute } = makeJoinFundAction();
+    const maxAmount = "9".repeat(78); // 10^78 - 1, the largest NUMERIC(78,0) value
+    await action.joinAndFundAgentAddress({ ruleId: ruleIdHex, bridge: "eth_truf", amount: maxAmount });
+    expect(execute.mock.calls[0][0].inputs[0].$amount).toBe(maxAmount);
   });
 
   it("throws unknown rule_id when the rule does not exist, without submitting", async () => {

--- a/src/contracts-api/maaActions.test.ts
+++ b/src/contracts-api/maaActions.test.ts
@@ -1,6 +1,7 @@
 import { KwilSigner, NodeKwil, Utils } from "@trufnetwork/kwil-js";
 import { describe, it, expect, vi } from "vitest";
 import { MAAAction } from "./maaActions";
+import { MAAAddress } from "../util/MAAAddress";
 
 /**
  * Pure-unit tests for executeAgentAction (the maa_exec submission wrapper). The wire encoding and
@@ -122,6 +123,128 @@ describe("MAAAction.executeAgentAction", () => {
 
     await expect(
       action.executeAgentAction({ maaAddress: addr20Hex, action: "a" }),
+    ).rejects.toThrow("no transaction hash returned");
+  });
+});
+
+/**
+ * Pure-unit tests for joinAndFundAgentAddress (the maa_join_and_fund submission wrapper). Like
+ * joinAgentAddress it resolves the rule off-chain to derive the wallet locally, then submits one
+ * execute; the added funding leg only threads $bridge and a NUMERIC-pinned $amount into that same
+ * action. Both the getRule read (call) and the write (execute) are mocked; on-chain atomicity is
+ * covered by the node integration tests.
+ */
+describe("MAAAction.joinAndFundAgentAddress", () => {
+  const ruleIdBytes = new Uint8Array(32).fill(0xab);
+  const ruleIdHex = "0x" + "ab".repeat(32);
+  const restrictedHex = "0x" + "11".repeat(20);
+  const ownerHex = "0x" + "22".repeat(20);
+
+  /** getRule reads maa_get_rule; only restricted_addr is used, to derive the wallet locally. */
+  const ruleRow = {
+    rule_id: ruleIdHex,
+    restricted_addr: restrictedHex,
+    rules_hash: "0x" + "00".repeat(32),
+    fee_mode: "bps",
+    fee_bps: 250,
+    fee_flat: "0",
+    created_at: 1,
+  };
+
+  /**
+   * Builds an action whose kwil client answers the getRule `call` with a supplied rule row (or none)
+   * and the write `execute` with a tx hash. Records both mocks for assertions. callerAddress is the
+   * owner so ownerBytes() resolves without a real signer.
+   */
+  function makeJoinFundAction(opts: { rule?: any; txHash?: string } = {}) {
+    const call = vi.fn().mockResolvedValue({
+      status: 200,
+      data: { result: opts.rule === null ? [] : [opts.rule ?? ruleRow] },
+    });
+    const execute = vi.fn().mockResolvedValue(
+      "txHash" in opts ? { data: opts.txHash ? { tx_hash: opts.txHash } : {} } : { data: { tx_hash: "0xfund" } },
+    );
+    const mockKwil = { call, execute } as unknown as NodeKwil;
+    const action = new MAAAction(mockKwil, mockSigner, ownerHex);
+    return { action, call, execute };
+  }
+
+  it("submits maa_join_and_fund with a NUMERIC-pinned amount and returns the derived wallet + tx hash", async () => {
+    const { action, execute } = makeJoinFundAction();
+
+    const res = await action.joinAndFundAgentAddress({
+      ruleId: ruleIdHex,
+      bridge: "eth_truf",
+      amount: "40000000000000000000",
+    });
+
+    // The wallet is derived locally from (owner, rule's restricted creator, rule_id).
+    const expected = MAAAddress.deriveMAAAddress(
+      new Uint8Array(20).fill(0x22),
+      restrictedHex,
+      ruleIdBytes,
+    );
+    expect(res.maaAddress).toEqual(expected);
+    expect(res.maaAddressHex).toBe(MAAAddress.deriveMAAAddressHex(ownerHex, restrictedHex, ruleIdBytes));
+    expect(res.txHash).toBe("0xfund");
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const body = execute.mock.calls[0][0];
+    expect(body.name).toBe("maa_join_and_fund");
+    expect(body.namespace).toBe("main");
+    expect(body.inputs).toEqual([
+      { $rule_id: ruleIdBytes, $bridge: "eth_truf", $amount: "40000000000000000000" },
+    ]);
+    expect(body.types).toEqual({ $amount: Utils.DataType.Numeric(78, 0) });
+  });
+
+  it("accepts a raw 32-byte rule id", async () => {
+    const { action, execute } = makeJoinFundAction();
+    await action.joinAndFundAgentAddress({ ruleId: ruleIdBytes, bridge: "hoodi_tt", amount: "1" });
+    expect(execute.mock.calls[0][0].inputs[0].$rule_id).toEqual(ruleIdBytes);
+  });
+
+  it("rejects a rule id that is not 32 bytes before any call", async () => {
+    const { action, call, execute } = makeJoinFundAction();
+    await expect(
+      action.joinAndFundAgentAddress({ ruleId: "0x" + "ab".repeat(31), bridge: "eth_truf", amount: "1" }),
+    ).rejects.toThrow("rule_id must be 32 bytes");
+    expect(call).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty bridge before any call", async () => {
+    const { action, call, execute } = makeJoinFundAction();
+    await expect(
+      action.joinAndFundAgentAddress({ ruleId: ruleIdHex, bridge: "  ", amount: "1" }),
+    ).rejects.toThrow("bridge is required");
+    expect(call).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive or non-integer amount before any call", async () => {
+    for (const amount of ["0", "-1", "1.5", "", "abc"]) {
+      const { action, call, execute } = makeJoinFundAction();
+      await expect(
+        action.joinAndFundAgentAddress({ ruleId: ruleIdHex, bridge: "eth_truf", amount }),
+      ).rejects.toThrow("Amount must be greater than 0");
+      expect(call).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+    }
+  });
+
+  it("throws unknown rule_id when the rule does not exist, without submitting", async () => {
+    const { action, execute } = makeJoinFundAction({ rule: null });
+    await expect(
+      action.joinAndFundAgentAddress({ ruleId: ruleIdHex, bridge: "eth_truf", amount: "1" }),
+    ).rejects.toThrow("unknown rule_id");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("throws when the node returns no tx hash", async () => {
+    const { action } = makeJoinFundAction({ txHash: "" });
+    await expect(
+      action.joinAndFundAgentAddress({ ruleId: ruleIdHex, bridge: "eth_truf", amount: "1" }),
     ).rejects.toThrow("no transaction hash returned");
   });
 });

--- a/src/contracts-api/maaActions.ts
+++ b/src/contracts-api/maaActions.ts
@@ -19,6 +19,7 @@ import {
   MAAEvent,
   MAAExecuteInput,
   MAAInstance,
+  MAAJoinAndFundInput,
   MAAJoinResult,
   MAAOwnedWallet,
   MAARule,
@@ -121,6 +122,51 @@ export class MAAAction extends Action {
     const txHash = result.data?.tx_hash;
     if (!txHash) {
       throw new Error("joinAgentAddress: no transaction hash returned");
+    }
+    return { txHash, maaAddress, maaAddressHex: hexlify(maaAddress) };
+  }
+
+  /**
+   * joinAndFundAgentAddress joins a rule and funds the derived agent wallet in one atomic transaction:
+   * the caller (signer) becomes the owner and, in the same on-chain action, transfers `amount` of the
+   * chosen bridged token from their own balance into the new wallet. Either both legs commit or neither
+   * does, so activation cannot strand a joined-but-unfunded wallet — unlike a joinAgentAddress followed
+   * by a separate transfer. Returns the locally-derived MAA address and the submission tx hash.
+   *
+   * The caller must already hold at least `amount` of `bridge` on TN (funds arriving from L1 are a
+   * bridge deposit, which is a separate cross-chain step). Requires the on-chain maa_join_and_fund
+   * action (node migration 054) to be deployed on the target network.
+   */
+  async joinAndFundAgentAddress(input: MAAJoinAndFundInput): Promise<MAAJoinResult> {
+    const idBytes = toBytes(input.ruleId);
+    if (idBytes.length !== 32) {
+      throw new Error(`rule_id must be 32 bytes, got ${idBytes.length}`);
+    }
+    if (!input.bridge || input.bridge.trim() === "") {
+      throw new Error("bridge is required");
+    }
+    // Same positive-integer-base-units contract as the bridged-token transfer.
+    if (!/^[0-9]+$/.test(input.amount) || BigInt(input.amount) <= 0n) {
+      throw new Error(`Invalid amount: ${input.amount}. Amount must be greater than 0.`);
+    }
+    const unrestricted = this.ownerBytes();
+
+    // Resolve the rule's restricted creator so the wallet can be derived locally (also validates the rule).
+    const rule = await this.getRule(idBytes);
+    if (!rule) {
+      throw new Error("unknown rule_id");
+    }
+    const maaAddress = MAAAddress.deriveMAAAddress(unrestricted, rule.restricted, idBytes);
+
+    // $amount is NUMERIC(78,0) on-chain; pin it so a plain JS string isn't inferred as text.
+    const result = await this.executeWithNamedParams(
+      "maa_join_and_fund",
+      [{ $rule_id: idBytes, $bridge: input.bridge, $amount: input.amount }],
+      { $amount: Utils.DataType.Numeric(78, 0) },
+    );
+    const txHash = result.data?.tx_hash;
+    if (!txHash) {
+      throw new Error("joinAndFundAgentAddress: no transaction hash returned");
     }
     return { txHash, maaAddress, maaAddressHex: hexlify(maaAddress) };
   }

--- a/src/contracts-api/maaActions.ts
+++ b/src/contracts-api/maaActions.ts
@@ -145,9 +145,17 @@ export class MAAAction extends Action {
     if (!input.bridge || input.bridge.trim() === "") {
       throw new Error("bridge is required");
     }
-    // Same positive-integer-base-units contract as the bridged-token transfer.
-    if (!/^[0-9]+$/.test(input.amount) || BigInt(input.amount) <= 0n) {
-      throw new Error(`Invalid amount: ${input.amount}. Amount must be greater than 0.`);
+    // $amount is NUMERIC(78,0): a positive base-10 integer string in base units, at most 78 digits
+    // (max 10^78 - 1). Reject a non-string, a non-integer, or an over-precision value locally rather
+    // than round-tripping to a node overflow.
+    if (
+      typeof input.amount !== "string" ||
+      !/^[0-9]{1,78}$/.test(input.amount) ||
+      BigInt(input.amount) <= 0n
+    ) {
+      throw new Error(
+        `Invalid amount: ${input.amount}. Amount must be a positive base-10 integer string within NUMERIC(78,0) (at most 78 digits).`,
+      );
     }
     const unrestricted = this.ownerBytes();
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -113,6 +113,7 @@ export type {
   MAACreateRuleInput,
   MAACreateRuleResult,
   MAAJoinResult,
+  MAAJoinAndFundInput,
   MAAExecuteInput,
   MAARule,
   MAAAllowedAction,

--- a/src/types/maa.ts
+++ b/src/types/maa.ts
@@ -52,7 +52,10 @@ export interface MAAJoinAndFundInput {
   ruleId: MAABytesLike;
   /** Bridge identifier the funds are held under (e.g. "eth_truf" on mainnet, "hoodi_tt" on dev). */
   bridge: string;
-  /** Funding amount in the token's base units, as a decimal string (must be greater than 0). */
+  /**
+   * Funding amount in the token's base units, as a positive base-10 integer string. Must fit
+   * NUMERIC(78,0) — at most 78 digits (max 10^78 - 1).
+   */
   amount: string;
 }
 

--- a/src/types/maa.ts
+++ b/src/types/maa.ts
@@ -43,6 +43,20 @@ export interface MAAJoinResult {
 }
 
 /**
+ * Parameters for joinAndFundAgentAddress (on-chain maa_join_and_fund): join a rule and fund the
+ * derived wallet in one atomic transaction. The caller (signer) must already hold `amount` of the
+ * bridged token on TN; both the join and the funding transfer commit together or not at all.
+ */
+export interface MAAJoinAndFundInput {
+  /** 32-byte rule_id to join, as 0x-hex or raw bytes. */
+  ruleId: MAABytesLike;
+  /** Bridge identifier the funds are held under (e.g. "eth_truf" on mainnet, "hoodi_tt" on dev). */
+  bridge: string;
+  /** Funding amount in the token's base units, as a decimal string (must be greater than 0). */
+  amount: string;
+}
+
+/**
  * Parameters for executeAgentAction (a maa_exec transaction: run an inner action AS the agent wallet).
  *
  * The signer is either the rule's restricted agent (running a delegated, allow-listed action) or the


### PR DESCRIPTION
Adds `joinAndFundAgentAddress`, so someone who already holds TRUF or USDC on TN can join a rule and fund the derived agent wallet in one signed transaction, instead of a join followed by a separate transfer. Either both legs commit or neither does, so activation can no longer strand a joined-but-unfunded wallet.

resolves: trufnetwork/truf-network#1399

A kwil transaction runs exactly one action, so join + transfer can only be atomic inside a single on-chain action. That action shipped in the node (`maa_join_and_fund`, merged in trufnetwork/node#1409); this exposes it as one SDK call.

## What is here

- `src/contracts-api/maaActions.ts` — `joinAndFundAgentAddress({ ruleId, bridge, amount })`. Mirrors `joinAgentAddress`: it resolves the rule on-chain and derives the wallet locally, so the caller learns the address before broadcast, then submits one `execute`. The `$amount` is pinned to `Numeric(78, 0)` so a plain JS string reaches the node as NUMERIC, not TEXT (the same pin `createAgentRule` uses for `$fee_flat`). Returns the derived address and the submission tx hash.
- `src/types/maa.ts` — `MAAJoinAndFundInput`; `src/internal.ts` — export.
- `examples/maa_lifecycle_example/README.md` — a note on the atomic path next to the two-step flow.

## Notes for review

- **Amount contract**: positive integer base units, the same rule as the bridged-token transfer. The caller must already hold the funds on TN; bringing tokens in from L1 is a separate bridge deposit, so it isn't part of this call.
- **Validation runs before the network read**: a bad rule id, empty bridge, or non-positive amount rejects before `getRule` and before broadcast.
- **Deployment dependency**: the method calls the on-chain `maa_join_and_fund` action (node migration 054). It errors on a live call until that migration is deployed to the target network.

## Testing

`npm run test:unit` green (326 tests, 8 new): the NUMERIC pin, local address derivation, raw-bytes rule id, and every guard (bad rule length, empty bridge, non-positive or non-integer amount, unknown rule, missing tx hash). Typecheck and build clean. Live end-to-end verification follows once the node action is deployed to testnet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `joinAndFundAgentAddress` for atomically joining and funding a Modular Agent Address in a single on-chain transaction.
  * Includes input validation for `ruleId`, `bridge`, and funding `amount`, and returns the transaction hash plus the derived agent wallet address.
* **Tests**
  * Added unit tests covering request construction, validation edge cases, and missing-response failure modes.
* **Documentation**
  * Added an end-to-end example (README, `.env.example`, and runnable script) demonstrating an atomic activation smoke test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->