### PR TITLE
feat: market forecast

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1524,7 +1524,7 @@ Prediction markets price **ranges**, not values. A five-bucket EPS market says
 $2.14". These helpers invert that, collapsing the order books across every
 bucket of one market into the single number they collectively imply.
 
-```
+```text
 market says                     ->  forecast says
 "34% between 2.06 and 2.21"         "2.14, p10..p90 1.91..2.38"
 ```
@@ -1554,8 +1554,14 @@ YES liquidity and ignoring it would discard real quotes.
 ```typescript
 const forecast = await orderbook.getMarketForecast([419, 420, 421, 422, 423]);
 if (forecast) {
-  console.log(forecast.value.toFixed(4));                              // 2.1362
-  console.log(`${forecast.p10!.toFixed(4)}..${forecast.p90!.toFixed(4)}`); // 1.9053..2.3792
+  console.log(forecast.value.toFixed(4)); // 2.1362
+
+  // p10/p90 are null when the market has too few strikes to place them.
+  const band =
+    forecast.p10 !== null && forecast.p90 !== null
+      ? `${forecast.p10.toFixed(4)}..${forecast.p90.toFixed(4)}`
+      : "unresolved";
+  console.log(band); // 1.9053..2.3792
 
   for (const bucket of forecast.buckets) {
     console.log(`  ${bucket.lower}-${bucket.upper}: ${(bucket.probability * 100).toFixed(1)}%`);
@@ -1609,18 +1615,23 @@ set of them. They can be reassembled from chain data alone: buckets of the same
 market share a data stream and a settlement time.
 
 ```typescript
-import { decodeMarketData, bucketBoundsFromMarketData } from "@trufnetwork/sdk-js";
+import { decodeMarketData } from "@trufnetwork/sdk-js";
 
 const groups = new Map<string, number[]>();
 for (const summary of await orderbook.listMarkets({ settledFilter: false, limit: 100 })) {
   const info = await orderbook.getMarketInfo(summary.id);
+  // Legacy markets carry no query_components and cannot be decoded.
+  if (!info.queryComponents || info.queryComponents.length === 0) continue;
   const marketData = decodeMarketData(info.queryComponents);
   const key = `${marketData.streamId}@${summary.settleTime}`;
   groups.set(key, [...(groups.get(key) ?? []), summary.id]);
 }
 
-// A complete market tiles the line: one "below" bucket, one "above", ranges between.
+// A complete market tiles the line: one "below" bucket, one "above", ranges
+// between. A stream can also carry a market that is not part of a bucket set at
+// all, so skip anything too small to forecast rather than letting it throw.
 for (const [, queryIds] of groups) {
+  if (queryIds.length < 2) continue;
   const forecast = await orderbook.getMarketForecast(queryIds);
 }
 ```
@@ -1664,8 +1675,12 @@ const fromQuotes = forecastFromBuckets([
 ] as BucketBook[]);
 ```
 
-Buckets must span the whole line, with the first open below (`lower: null`) and
-the last open above (`upper: null`).
+A complete market spans the whole line, with the first bucket open below
+(`lower: null`) and the last open above (`upper: null`). That is what the
+algorithm is designed for, but it is not enforced: an interior-only or gapped
+set still returns a forecast, with the problem reported in `warnings`. The mass
+beyond an unrepresented tail simply has nowhere to go, so treat those results
+accordingly.
 
 `bucketBoundsFromMarketData(marketData)` converts the output of
 `decodeMarketData` into a `{ lower, upper }` pair, handling the `below`,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1551,7 +1551,9 @@ One forecast covers the buckets of **one** market. A repeated query_id would
 have its bucket counted twice, and mixing two markets would normalise unrelated
 probabilities into a single distribution — both are rejected rather than warned
 about. Buckets of one market differ only in their strike, so the identity
-compared is `(dataProvider, streamId, settleTime, timestamp, frozenAt)`.
+compared is `(dataProvider, streamId, bridge, settleTime, timestamp, frozenAt)`
+— the bridge included because an identical question collateralised two ways is
+two markets with two separate books.
 
 **Cost:** two order-book reads plus one market-info read per bucket. Both the
 YES and NO books are fetched, because on this venue a resting BUY NO at *p* is

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1517,6 +1517,160 @@ console.log(`Buy Orders: ${collateral.buyOrdersLocked} wei`);
 console.log(`Shares Value: ${collateral.sharesValue} wei`);
 ```
 
+### Market Forecasting
+
+Prediction markets price **ranges**, not values. A five-bucket EPS market says
+"34% chance EPS lands between $2.06 and $2.21"; it never says "EPS will be
+$2.14". These helpers invert that, collapsing the order books across every
+bucket of one market into the single number they collectively imply.
+
+```
+market says                     ->  forecast says
+"34% between 2.06 and 2.21"         "2.14, p10..p90 1.91..2.38"
+```
+
+This is the same algorithm as `sdk-py`'s `get_market_forecast`, and the two are
+verified to produce the same numbers.
+
+#### `orderbook.getMarketForecast(queryIds: number[]): Promise<MarketForecast | null>`
+
+Collapses a market's bucket books into the single value they imply.
+
+**Parameters:**
+- `queryIds: number[]` — The bucket query_ids of **one** market. Order does not
+  matter; they are sorted by bound internally. See *Finding a market's
+  queryIds* below.
+
+**Returns:** A `MarketForecast`, or `null` when no bucket has a usable quote.
+
+**Throws:** if fewer than two query_ids are given, or a market is missing the
+`queryComponents` needed to derive its bounds.
+
+**Cost:** two order-book reads plus one market-info read per bucket. Both the
+YES and NO books are fetched, because on this venue a resting BUY NO at *p* is
+hittable by a BUY YES at *100-p* (mint match), so NO liquidity is executable
+YES liquidity and ignoring it would discard real quotes.
+
+```typescript
+const forecast = await orderbook.getMarketForecast([419, 420, 421, 422, 423]);
+if (forecast) {
+  console.log(forecast.value.toFixed(4));                              // 2.1362
+  console.log(`${forecast.p10!.toFixed(4)}..${forecast.p90!.toFixed(4)}`); // 1.9053..2.3792
+
+  for (const bucket of forecast.buckets) {
+    console.log(`  ${bucket.lower}-${bucket.upper}: ${(bucket.probability * 100).toFixed(1)}%`);
+  }
+  for (const warning of forecast.warnings) {
+    console.log(`  ! ${warning}`);
+  }
+}
+```
+
+#### `MarketForecast`
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `value` | `number` | The point estimate: the **median** of the implied distribution |
+| `p10`, `p90` | `number \| null` | The published band. The market implies an 80% chance the outcome lands inside it |
+| `marginOfError` | `number` | Half the P10..P90 band. **Not** a standard error — see below |
+| `sigma` | `number` | The band scaled to a normal-equivalent standard deviation |
+| `valueBasis` | `ForecastBasis` | `"interior"`, `"tail"`, or `"unresolved"` — see below |
+| `p10Basis`, `p90Basis` | `ForecastBasis` | Same flags, for each end of the band |
+| `method` | `ForecastMethod` | `"rank"` normally, `"discrete"` on a degenerate book |
+| `buckets` | `BucketEstimate[]` | Per-bucket detail |
+| `warnings` | `string[]` | Book-quality problems worth surfacing |
+| `multimodal`, `nPeaks` | `boolean`, `number` | Whether the book implies more than one peak |
+| `low`, `high` | `number` | `value -/+ marginOfError` |
+
+Each `BucketEstimate` carries `queryId`, `lower`, `upper`, `probability`
+(normalised, sums to 1), `rawProbability`, `confidence`, `oneSided` and
+`quoted`. `forecastToJSON(forecast)` gives a flat, JSON-serialisable form.
+
+**`marginOfError` is a band, not a precision.** It is half the P10..P90 spread,
+so it describes how uncertain the **outcome** is, not how tightly the book pins
+your estimate. Expect it to be large — on a live five-bucket EPS market, roughly
+0.24 against a value of 2.14. Publishing it as "± 0.24" is correct; reading it
+as "our estimate is accurate to 0.24" is not.
+
+**Check the `Basis` flags before displaying a number.** The outer two buckets are
+open-ended, so the books say nothing about how far out they extend. When a
+percentile falls inside one, an exponential tail model supplies the number and
+the corresponding flag reads `"tail"`. `"interior"` means it was read between
+real strikes with no shape assumption. `"unresolved"` means the market has too
+few strikes to place it at all.
+
+**Read `warnings`.** Unquoted or one-sided buckets, crossed books, and
+dutch-book deviations are reported rather than silently smoothed over.
+
+#### Finding a market's queryIds
+
+Each bucket is a **separate market** with its own query_id, so a "market" is a
+set of them. They can be reassembled from chain data alone: buckets of the same
+market share a data stream and a settlement time.
+
+```typescript
+import { decodeMarketData, bucketBoundsFromMarketData } from "@trufnetwork/sdk-js";
+
+const groups = new Map<string, number[]>();
+for (const summary of await orderbook.listMarkets({ settledFilter: false, limit: 100 })) {
+  const info = await orderbook.getMarketInfo(summary.id);
+  const marketData = decodeMarketData(info.queryComponents);
+  const key = `${marketData.streamId}@${summary.settleTime}`;
+  groups.set(key, [...(groups.get(key) ?? []), summary.id]);
+}
+
+// A complete market tiles the line: one "below" bucket, one "above", ranges between.
+for (const [, queryIds] of groups) {
+  const forecast = await orderbook.getMarketForecast(queryIds);
+}
+```
+
+A layout that does not tile the line is still estimated, with the problem
+reported in `warnings` rather than thrown.
+
+#### Forecasting from your own book data
+
+If you already hold the books, the algorithm is available as pure functions with
+no I/O. `forecastFromDepth` is the preferred entry point; it consolidates the
+YES and NO ladders itself.
+
+```typescript
+import {
+  forecastFromDepth,
+  forecastFromBuckets,
+  type BucketDepth,
+  type BucketBook,
+} from "@trufnetwork/sdk-js";
+
+// Full ladders. Prices are positive 1-99 cents on every side.
+const buckets: BucketDepth[] = [
+  {
+    lower: null,                          // null = open-ended outer bucket
+    upper: 1.91,
+    yesBids: [{ price: 4, size: 386 }],
+    yesAsks: [],
+    noBids: [{ price: 83, size: 25 }],
+    noAsks: [{ price: 97, size: 6 }],
+    queryId: 419,
+  },
+  // ... remaining buckets, ascending
+];
+const forecast = forecastFromDepth(buckets);
+
+// Or, if you only have top-of-book (no consolidation, weaker estimate):
+const fromQuotes = forecastFromBuckets([
+  { lower: null, upper: 1.91, bestBid: 4, bestAsk: 17, queryId: 419 },
+  // ...
+] as BucketBook[]);
+```
+
+Buckets must span the whole line, with the first open below (`lower: null`) and
+the last open above (`upper: null`).
+
+`bucketBoundsFromMarketData(marketData)` converts the output of
+`decodeMarketData` into a `{ lower, upper }` pair, handling the `below`,
+`between`, `above` and `equals` market types.
+
 ### Settlement Operations
 
 #### `orderbook.settleMarket(queryId: number): Promise<TxReceipt>`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1543,8 +1543,15 @@ Collapses a market's bucket books into the single value they imply.
 
 **Returns:** A `MarketForecast`, or `null` when no bucket has a usable quote.
 
-**Throws:** if fewer than two query_ids are given, or a market is missing the
+**Throws:** if fewer than two query_ids are given, if any is repeated, if they
+do not all belong to the same market, or if a market is missing the
 `queryComponents` needed to derive its bounds.
+
+One forecast covers the buckets of **one** market. A repeated query_id would
+have its bucket counted twice, and mixing two markets would normalise unrelated
+probabilities into a single distribution — both are rejected rather than warned
+about. Buckets of one market differ only in their strike, so the identity
+compared is `(dataProvider, streamId, settleTime, timestamp, frozenAt)`.
 
 **Cost:** two order-book reads plus one market-info read per bucket. Both the
 YES and NO books are fetched, because on this venue a resting BUY NO at *p* is

--- a/src/contracts-api/orderbookAction.ts
+++ b/src/contracts-api/orderbookAction.ts
@@ -735,19 +735,25 @@ export class OrderbookAction {
       const marketData = decodeMarketData(info.queryComponents);
 
       // Buckets of one market differ only in their strike: they share a data
-      // provider, a stream and a settlement time. Forecasting across two events
-      // would normalise unrelated probabilities into one distribution and
-      // return a confident number about nothing, so it is rejected rather than
-      // warned about.
+      // provider, a stream, a settlement time and the query time they observe.
+      // Forecasting across two events would normalise unrelated probabilities
+      // into one distribution and return a confident number about nothing, so
+      // it is rejected rather than warned about.
+      //
+      // The query's own timestamp and frozenAt are included, not just the
+      // settlement time: two markets can settle at the same moment while
+      // observing the stream at different points.
       const thisIdentity =
-        `${marketData.dataProvider}|${marketData.streamId}|${info.settleTime}`;
+        `${marketData.dataProvider}|${marketData.streamId}|${info.settleTime}` +
+        `|${marketData.timestamp}|${marketData.frozenAt}`;
       if (identity === null) {
         identity = thisIdentity;
       } else if (thisIdentity !== identity) {
         throw new Error(
           `market ${queryId} belongs to a different event than the first ` +
-            `bucket: (dataProvider, streamId, settleTime) is ${thisIdentity} ` +
-            `against ${identity}. One forecast covers the buckets of ONE market.`
+            `bucket: (dataProvider, streamId, settleTime, timestamp, frozenAt) ` +
+            `is ${thisIdentity} against ${identity}. One forecast covers the ` +
+            `buckets of ONE market.`
         );
       }
 

--- a/src/contracts-api/orderbookAction.ts
+++ b/src/contracts-api/orderbookAction.ts
@@ -49,6 +49,7 @@ import {
   encodeRangeActionArgs,
   encodeEqualsActionArgs,
   dbBytesToUint8Array,
+  decodeMarketData,
   validatePrice,
   validateAmount,
   validateBridge,
@@ -57,6 +58,13 @@ import {
   validateWalletHex,
   settledFilterToBoolean,
 } from "../util/orderbookHelpers";
+import { bucketBoundsFromMarketData } from "../util/marketBuckets";
+import { forecastFromDepth } from "../util/forecast";
+import type {
+  BookLevel,
+  BucketDepth,
+  MarketForecast,
+} from "../util/forecast";
 
 /**
  * OrderbookAction provides methods for interacting with binary prediction markets.
@@ -658,6 +666,130 @@ export class OrderbookAction {
       bestAsk: row.best_ask,
       spread: row.spread,
     };
+  }
+
+  /**
+   * Collapses a market's bucket books into the single value they imply.
+   *
+   * A prediction market prices ranges: each bucket is its own query_id with its
+   * own binary book. This reads every bucket's FULL YES and NO ladders and its
+   * bounds, then returns the one number the books collectively imply plus the
+   * band around it. See the `forecast` module for the algorithm.
+   *
+   * The YES and NO books are both fetched because the forecast consolidates
+   * them: on this venue a resting BUY NO at p is hittable by a BUY YES at 100-p
+   * (mint match), so NO liquidity is executable YES liquidity and ignoring it
+   * would discard real quotes. That costs two order-book reads per bucket.
+   *
+   * @param queryIds - The bucket query_ids of ONE market. Order does not matter,
+   *   they are sorted by lower bound here. The buckets are expected to tile the
+   *   whole line, with the bottom one open below and the top one open above; a
+   *   layout that does not is still estimated, with the problem reported in
+   *   `warnings`.
+   * @returns The forecast, or `null` when no bucket has a usable quote.
+   * @throws If fewer than two query_ids are given, or a market is missing the
+   *   query_components needed to derive its bounds.
+   *
+   * @example
+   * ```typescript
+   * const forecast = await orderbook.getMarketForecast([419, 420, 421, 422, 423]);
+   * if (forecast) {
+   *   console.log(forecast.value, forecast.p10, forecast.p90, forecast.warnings);
+   * }
+   * ```
+   */
+  async getMarketForecast(queryIds: number[]): Promise<MarketForecast | null> {
+    if (queryIds.length < 2) {
+      throw new Error(
+        `a market forecast needs at least 2 bucket query_ids, got ${queryIds.length}`
+      );
+    }
+
+    const books: BucketDepth[] = [];
+    for (const queryId of queryIds) {
+      const info = await this.getMarketInfo(queryId);
+      if (!info.queryComponents || info.queryComponents.length === 0) {
+        throw new Error(
+          `market ${queryId} has no query_components, so its bucket bounds ` +
+            `cannot be derived`
+        );
+      }
+      const { lower, upper } = bucketBoundsFromMarketData(
+        decodeMarketData(info.queryComponents)
+      );
+      const yes = await this.orderBookLadders(queryId, true);
+      const no = await this.orderBookLadders(queryId, false);
+      books.push({
+        lower,
+        upper,
+        yesBids: yes.bids,
+        yesAsks: yes.asks,
+        noBids: no.bids,
+        noAsks: no.asks,
+        queryId,
+      });
+    }
+
+    // Open below sorts first, which is where that bucket belongs.
+    books.sort((a, b) => {
+      if (a.lower === null) return b.lower === null ? 0 : -1;
+      if (b.lower === null) return 1;
+      return a.lower - b.lower;
+    });
+
+    const layout: string[] = [];
+    if (books[0].lower !== null) {
+      layout.push("lowest bucket is not open below");
+    }
+    if (books[books.length - 1].upper !== null) {
+      layout.push("highest bucket is not open above");
+    }
+    let breaks = 0;
+    for (let i = 0; i + 1 < books.length; i++) {
+      if (books[i].upper !== books[i + 1].lower) breaks += 1;
+    }
+    if (breaks) {
+      layout.push(`${breaks} gap(s) or overlap(s) between bucket bounds`);
+    }
+
+    const forecast = forecastFromDepth(books);
+    if (forecast === null) return null;
+    forecast.warnings.unshift(...layout);
+    return forecast;
+  }
+
+  /**
+   * One outcome's resting book, split into bid and ask ladders.
+   *
+   * `getOrderBook` marks bids with a NEGATIVE price and asks with a positive
+   * one; price 0 means shares held with no resting order, which is not part of
+   * the book. Prices come back to the forecast as the positive 1-99 cent
+   * convention it expects.
+   *
+   * Both fields are coerced with Number() rather than trusted: the node returns
+   * `amount` as a NUMERIC, which arrives over the wire as a STRING even though
+   * OrderBookEntry types it as a number. Left uncoerced it survives
+   * multiplication (JS coerces) but turns `+=` into string concatenation, so the
+   * bug would hide until some future reader of the ladder happened to sum sizes.
+   *
+   * @internal
+   */
+  private async orderBookLadders(
+    queryId: number,
+    outcome: boolean
+  ): Promise<{ bids: BookLevel[]; asks: BookLevel[] }> {
+    const bids: BookLevel[] = [];
+    const asks: BookLevel[] = [];
+    for (const entry of await this.getOrderBook(queryId, outcome)) {
+      const price = Number(entry.price);
+      const size = Number(entry.amount);
+      if (price < 0) {
+        bids.push({ price: -price, size });
+      } else if (price > 0) {
+        asks.push({ price, size });
+      }
+    }
+    return { bids, asks };
   }
 
   /**

--- a/src/contracts-api/orderbookAction.ts
+++ b/src/contracts-api/orderbookAction.ts
@@ -58,7 +58,10 @@ import {
   validateWalletHex,
   settledFilterToBoolean,
 } from "../util/orderbookHelpers";
-import { bucketBoundsFromMarketData } from "../util/marketBuckets";
+import {
+  bucketBoundsFromMarketData,
+  requireQueryTime,
+} from "../util/marketBuckets";
 import { forecastFromDepth } from "../util/forecast";
 import type {
   BookLevel,
@@ -743,15 +746,22 @@ export class OrderbookAction {
       // The query's own timestamp and frozenAt are included, not just the
       // settlement time: two markets can settle at the same moment while
       // observing the stream at different points.
+      //
+      // The bridge is in here too, and it is the one field that lives outside
+      // the query components: it is a createMarket argument, so two markets can
+      // ask an identical question while collateralising it differently. Those
+      // are separate markets with separate books.
+      requireQueryTime(queryId, marketData);
       const thisIdentity =
-        `${marketData.dataProvider}|${marketData.streamId}|${info.settleTime}` +
-        `|${marketData.timestamp}|${marketData.frozenAt}`;
+        `${marketData.dataProvider}|${marketData.streamId}|${info.bridge}` +
+        `|${info.settleTime}|${marketData.timestamp}|${marketData.frozenAt}`;
       if (identity === null) {
         identity = thisIdentity;
       } else if (thisIdentity !== identity) {
         throw new Error(
           `market ${queryId} belongs to a different event than the first ` +
-            `bucket: (dataProvider, streamId, settleTime, timestamp, frozenAt) ` +
+            `bucket: (dataProvider, streamId, bridge, settleTime, timestamp, ` +
+            `frozenAt) ` +
             `is ${thisIdentity} against ${identity}. One forecast covers the ` +
             `buckets of ONE market.`
         );

--- a/src/contracts-api/orderbookAction.ts
+++ b/src/contracts-api/orderbookAction.ts
@@ -704,21 +704,54 @@ export class OrderbookAction {
         `a market forecast needs at least 2 bucket query_ids, got ${queryIds.length}`
       );
     }
+    if (new Set(queryIds).size !== queryIds.length) {
+      const repeated = [
+        ...new Set(queryIds.filter((id, i) => queryIds.indexOf(id) !== i)),
+      ].sort((a, b) => a - b);
+      throw new Error(
+        `duplicate bucket query_ids ${repeated.join(", ")}; a repeated bucket ` +
+          `would have its probability counted twice`
+      );
+    }
 
     const books: BucketDepth[] = [];
+    let identity: string | null = null;
     for (const queryId of queryIds) {
-      const info = await this.getMarketInfo(queryId);
+      // The three reads are independent, so overlap them. Buckets stay
+      // sequential: fanning every bucket out at once would put 3N simultaneous
+      // calls on the gateway for no benefit the caller asked for.
+      const [info, yes, no] = await Promise.all([
+        this.getMarketInfo(queryId),
+        this.orderBookLadders(queryId, true),
+        this.orderBookLadders(queryId, false),
+      ]);
+
       if (!info.queryComponents || info.queryComponents.length === 0) {
         throw new Error(
           `market ${queryId} has no query_components, so its bucket bounds ` +
             `cannot be derived`
         );
       }
-      const { lower, upper } = bucketBoundsFromMarketData(
-        decodeMarketData(info.queryComponents)
-      );
-      const yes = await this.orderBookLadders(queryId, true);
-      const no = await this.orderBookLadders(queryId, false);
+      const marketData = decodeMarketData(info.queryComponents);
+
+      // Buckets of one market differ only in their strike: they share a data
+      // provider, a stream and a settlement time. Forecasting across two events
+      // would normalise unrelated probabilities into one distribution and
+      // return a confident number about nothing, so it is rejected rather than
+      // warned about.
+      const thisIdentity =
+        `${marketData.dataProvider}|${marketData.streamId}|${info.settleTime}`;
+      if (identity === null) {
+        identity = thisIdentity;
+      } else if (thisIdentity !== identity) {
+        throw new Error(
+          `market ${queryId} belongs to a different event than the first ` +
+            `bucket: (dataProvider, streamId, settleTime) is ${thisIdentity} ` +
+            `against ${identity}. One forecast covers the buckets of ONE market.`
+        );
+      }
+
+      const { lower, upper } = bucketBoundsFromMarketData(marketData);
       books.push({
         lower,
         upper,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -170,6 +170,41 @@ export {
 
 export type { MarketData, CreateMarketPayload } from "./util/orderbookHelpers";
 
+// Market forecasting: the single value a market's bucket order books imply.
+export {
+  bucketProbability,
+  bucketEstimateFromDepth,
+  typicalHalfSpread,
+  forecastFromBuckets,
+  forecastFromDepth,
+  consolidatedBids,
+  consolidatedAsks,
+  bestView,
+  usableBid,
+  usableAsk,
+  forecastToJSON,
+  DEPTH_MIN_SIDE_NOTIONAL_USD,
+  LOW_TOTAL_NOTIONAL_WARN_USD,
+  MIN_QUOTE_NOTIONAL_CENT_SHARES,
+  PEAK_PROMINENCE,
+} from "./util/forecast";
+
+export type {
+  BookLevel,
+  BucketBook,
+  BucketDepth,
+  BucketEstimate,
+  BucketQuoteEstimate,
+  BucketDepthEstimate,
+  MarketForecast,
+  MarketForecastJSON,
+  ForecastBasis,
+  ForecastMethod,
+} from "./util/forecast";
+
+export { bucketBoundsFromMarketData } from "./util/marketBuckets";
+export type { BucketBounds } from "./util/marketBuckets";
+
 // Local actions types
 export type {
   ILocalActions,

--- a/src/util/forecast.test.ts
+++ b/src/util/forecast.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the market-implied point forecast (best-quote path).
+ *
+ * Ported case-for-case from sdk-py's tests/test_forecast.py, which is itself the
+ * upstream prediction-bots suite. Keeping the cases aligned is what proves the
+ * two SDKs agree: forecast.ts is a hand translation, so behaviour is the only
+ * thing that can be diffed.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  BucketBook,
+  bucketProbability,
+  forecastFromBuckets,
+  forecastToJSON,
+} from "./forecast";
+
+// MSFT EPS 2026 Q3 bucket layout, as configured on mainnet.
+const MSFT_BOUNDS: [number | null, number | null][] = [
+  [null, 4.04],
+  [4.04, 4.33],
+  [4.33, 4.62],
+  [4.62, 4.92],
+  [4.92, null],
+];
+
+/** Books quoting each bucket at the given cents, with a symmetric spread. */
+function build(
+  cents: (number | null)[],
+  bounds: [number | null, number | null][] = MSFT_BOUNDS,
+  spread = 2
+): BucketBook[] {
+  return bounds.map(([lower, upper], i) => {
+    const c = cents[i];
+    if (c === null || c === undefined) return { lower, upper };
+    return {
+      lower,
+      upper,
+      bestBid: Math.max(1, c - spread / 2),
+      bestAsk: Math.min(99, c + spread / 2),
+    };
+  });
+}
+
+/** `forecastFromBuckets`, asserting it produced something. */
+function forecast(buckets: BucketBook[]) {
+  const f = forecastFromBuckets(buckets);
+  expect(f).not.toBeNull();
+  return f!;
+}
+
+describe("bucketProbability", () => {
+  it("takes the midpoint of a two-sided quote", () => {
+    const { probability, confidence, oneSided, quoted } = bucketProbability(
+      38,
+      42
+    );
+    expect(probability).toBeCloseTo(0.4, 10);
+    expect(confidence).toBeCloseTo(0.96, 10);
+    expect(oneSided).toBe(false);
+    expect(quoted).toBe(true);
+  });
+
+  it("is more confident about a tighter spread", () => {
+    const tight = bucketProbability(39, 41).confidence;
+    const wide = bucketProbability(20, 60).confidence;
+    expect(tight).toBeGreaterThan(wide);
+  });
+
+  it("steps a one-sided book across by the half spread", () => {
+    // A lone bid is real information, but it is a BID: the fair value sits a
+    // half-spread above it, not at the midpoint of [bid, 1].
+    const { probability, confidence, oneSided, quoted } = bucketProbability(
+      30,
+      null,
+      0.06
+    );
+    expect(oneSided).toBe(true);
+    expect(quoted).toBe(true);
+    expect(probability).toBeCloseTo(0.36, 10);
+    expect(confidence).toBeLessThan(0.75);
+  });
+
+  it("does not read a lone penny bid as a coin flip", () => {
+    // The bug live books exposed: the [0.01, 1.0] midpoint made dead tails 50%.
+    const { probability } = bucketProbability(1, null, 0.06);
+    expect(probability).toBeCloseTo(0.07, 10);
+    expect(probability!).toBeLessThan(0.15);
+  });
+
+  it("returns null rather than a number for an empty book", () => {
+    const { probability, confidence, oneSided, quoted } = bucketProbability(
+      null,
+      null
+    );
+    expect(probability).toBeNull();
+    expect(confidence).toBe(0);
+    expect(quoted).toBe(false);
+    expect(oneSided).toBe(false);
+  });
+
+  it("distrusts a crossed book", () => {
+    expect(bucketProbability(60, 40).confidence).toBeLessThanOrEqual(1e-3);
+  });
+});
+
+describe("forecastFromBuckets: the core estimate", () => {
+  it("centres a symmetric market on the middle bucket", () => {
+    // Mass symmetric about bucket 3 must imply its midpoint, (4.33+4.62)/2.
+    const f = forecast(build([5, 20, 50, 20, 5]));
+    expect(f.method).toBe("rank");
+    expect(Math.abs(f.value - 4.475)).toBeLessThan(0.03);
+    expect(f.valueBasis).toBe("interior");
+  });
+
+  it("moves with the mass", () => {
+    const low = forecast(build([40, 30, 20, 7, 3])).value;
+    const mid = forecast(build([5, 20, 50, 20, 5])).value;
+    const high = forecast(build([3, 7, 20, 30, 40])).value;
+    expect(low).toBeLessThan(mid);
+    expect(mid).toBeLessThan(high);
+  });
+
+  it("lands inside the leading bucket", () => {
+    const f = forecast(build([5, 10, 60, 20, 5]));
+    expect(f.value).toBeGreaterThanOrEqual(4.33);
+    expect(f.value).toBeLessThanOrEqual(4.62);
+  });
+
+  it("needs no assumed value for the open tails", () => {
+    // Heavy mass in the unbounded top bucket must still give a finite answer
+    // that sits above the last boundary.
+    const f = forecast(build([1, 2, 7, 20, 70]));
+    expect(Number.isFinite(f.value)).toBe(true);
+    expect(f.value).toBeGreaterThan(4.92);
+  });
+
+  it("normalises the probabilities", () => {
+    const f = forecast(build([10, 25, 55, 25, 10])); // sums to 125c
+    const total = f.buckets.reduce((a, b) => a + b.probability, 0);
+    expect(total).toBeCloseTo(1, 10);
+    expect(f.warnings.some((w) => w.includes("sum to"))).toBe(true);
+  });
+});
+
+describe("forecastFromBuckets: the two uncertainties", () => {
+  it("publishes the band as the uncertainty statement", () => {
+    // Under the rank method the band IS the uncertainty statement: the market
+    // says the outcome lands in [p10, p90] with 80% probability. margin and
+    // sigma are derived from it for compatibility.
+    const f = forecast(build([5, 20, 50, 20, 5]));
+    expect(f.p10).not.toBeNull();
+    expect(f.p90).not.toBeNull();
+    expect(f.p10!).toBeLessThan(f.value);
+    expect(f.value).toBeLessThan(f.p90!);
+    expect(f.marginOfError).toBeCloseTo((f.p90! - f.p10!) / 2, 10);
+    expect(f.sigma).toBeCloseTo((f.p90! - f.p10!) / 2.5631, 10);
+  });
+
+  it("pins the value better on tight books than on wide ones", () => {
+    const tight = forecast(build([5, 20, 50, 20, 5], MSFT_BOUNDS, 2));
+    const wide = forecast(build([5, 20, 50, 20, 5], MSFT_BOUNDS, 30));
+    expect(wide.marginOfError).toBeGreaterThan(tight.marginOfError);
+  });
+
+  it("widens the margin on one-sided books", () => {
+    const twoSided = forecast(build([5, 20, 50, 20, 5]));
+    const half: BucketBook[] = MSFT_BOUNDS.map(([lower, upper], i) => ({
+      lower,
+      upper,
+      bestBid: [5, 20, 50, 20, 5][i],
+      bestAsk: null,
+    }));
+    const oneSided = forecast(half);
+    expect(oneSided.marginOfError).toBeGreaterThan(twoSided.marginOfError);
+    expect(oneSided.warnings.some((w) => w.includes("one-sided"))).toBe(true);
+  });
+
+  it("brackets the value with low and high", () => {
+    const f = forecast(build([5, 20, 50, 20, 5]));
+    expect(f.low).toBeLessThan(f.value);
+    expect(f.value).toBeLessThan(f.high);
+    expect(f.high - f.low).toBeCloseTo(2 * f.marginOfError, 10);
+  });
+});
+
+describe("forecastFromBuckets: degenerate input", () => {
+  it("returns null when nothing is quoted", () => {
+    expect(forecastFromBuckets(build([null, null, null, null, null]))).toBeNull();
+  });
+
+  it("returns null for too few buckets", () => {
+    expect(
+      forecastFromBuckets([
+        { lower: null, upper: 4.0, bestBid: 40, bestAsk: 44 },
+      ])
+    ).toBeNull();
+  });
+
+  it("still estimates from a partial book", () => {
+    const f = forecast(build([null, 20, 50, 20, null]));
+    expect(Number.isFinite(f.value)).toBe(true);
+    expect(f.warnings.some((w) => w.includes("unquoted"))).toBe(true);
+  });
+
+  it("gives unquoted buckets the residual, not a flat half", () => {
+    // Quoted buckets sum to ~0.9, so the two unquoted ones share ~0.1 between
+    // them, rather than being handed 0.5 each and swamping the distribution.
+    const f = forecast(build([null, 20, 50, 20, null]));
+    const probs = f.buckets.map((b) => b.probability);
+    expect(probs[0]).toBeCloseTo(probs[4], 10);
+    expect(probs[0]).toBeLessThan(0.1);
+    expect(probs[2]).toBeGreaterThan(0.4);
+  });
+
+  it("does not let dead tails dominate a live middle", () => {
+    // Reproduces the live MSFT book: penny-bid one-sided tails around a tight
+    // two-sided middle. The tails must not come out level with the leader.
+    const f = forecast([
+      { lower: null, upper: 4.04, bestBid: 1, bestAsk: null },
+      { lower: 4.04, upper: 4.33, bestBid: 16, bestAsk: 28 },
+      { lower: 4.33, upper: 4.62, bestBid: 44, bestAsk: 56 },
+      { lower: 4.62, upper: 4.92, bestBid: 9, bestAsk: 21 },
+      { lower: 4.92, upper: null, bestBid: 1, bestAsk: null },
+    ]);
+    const probs = f.buckets.map((b) => b.probability);
+    expect(probs[2]).toBe(Math.max(...probs));
+    expect(probs[0]).toBeLessThan(0.15);
+    expect(probs[4]).toBeLessThan(0.15);
+    expect(f.value).toBeGreaterThanOrEqual(4.2);
+    expect(f.value).toBeLessThanOrEqual(4.7);
+  });
+
+  it("does not explode when all the mass is in one bucket", () => {
+    const f = forecast(build([1, 1, 95, 1, 1]));
+    expect(Number.isFinite(f.value)).toBe(true);
+    expect(Number.isFinite(f.marginOfError)).toBe(true);
+    expect(f.value).toBeGreaterThanOrEqual(4.0);
+    expect(f.value).toBeLessThanOrEqual(5.0);
+  });
+
+  it("survives a flat book rather than dividing by zero", () => {
+    const f = forecast(build([20, 20, 20, 20, 20]));
+    expect(Number.isFinite(f.value)).toBe(true);
+  });
+
+  it("serialises to a flat form", () => {
+    const json = forecastToJSON(forecast(build([5, 20, 50, 20, 5])));
+    expect(Object.keys(json)).toEqual(
+      expect.arrayContaining([
+        "value",
+        "marginOfError",
+        "low",
+        "high",
+        "sigma",
+        "method",
+      ])
+    );
+    expect(json.probabilities).toHaveLength(5);
+    expect(JSON.parse(JSON.stringify(json))).toEqual(json);
+  });
+
+  it("survives a non-monotonic set of quotes", () => {
+    // Noisy quotes can imply a tiny negative probability step; the CDF walk must
+    // not trip over it.
+    const f = forecast(build([30, 1, 40, 1, 28]));
+    expect(Number.isFinite(f.value)).toBe(true);
+  });
+});

--- a/src/util/forecast.ts
+++ b/src/util/forecast.ts
@@ -1,0 +1,1246 @@
+/**
+ * Market-implied point forecast from prediction-market order book state.
+ *
+ * Prediction markets price RANGES. A five-bucket EPS market says "38% chance EPS
+ * lands between $4.33 and $4.62"; it never says "EPS will be $4.47". This module
+ * inverts that. Given the order books across every bucket of one market, it
+ * produces the single number the book is collectively implying, together with how
+ * tightly the book pins that number down.
+ *
+ *     market says            ->   this module says
+ *     "34% between 2.40-2.63"     "2.43, margin of error 0.02"
+ *
+ * ## How it works
+ *
+ * A market is N buckets, each its own query_id and its own binary book, and the
+ * outer two are open-ended:
+ *
+ *     bucket 1  (-inf, B1)      bucket 2  [B1, B2)   ...   bucket N  [Bn-1, +inf)
+ *
+ * Bounds are HALF-OPEN, matching how the markets are actually created
+ * (`value < upper`, `value >= lower AND value < upper`, `value >= lower`). So the
+ * buckets are mutually exclusive and exhaustive, and a value landing exactly on a
+ * boundary resolves the UPPER bucket only.
+ *
+ * 1. Each bucket's book implies a probability. Two-sided is the mid, with
+ *    confidence from how tight the spread is. One-sided takes the quoted side and
+ *    steps across by the market's own median half-spread, at reduced confidence:
+ *    on real books the open tail buckets are often bid-only at a penny, and
+ *    treating that as the midpoint of [0.01, 1.0] calls a dead tail a coin flip.
+ *    That single mistake handed MSFT's two tails 27% each and buried the real
+ *    distribution, so the rule matters more than it looks.
+ *
+ * 2. Bucket probabilities are normalised to sum to 1, since independent books
+ *    never sum to exactly 1 on their own because of spreads and staleness. A
+ *    bucket with no orders at all takes the residual the quoted buckets leave
+ *    behind rather than an invented value.
+ *
+ * 3. Those give the implied CDF at each interior boundary: the probability the
+ *    outcome lands at or below B_k is the sum of the buckets up to k.
+ *
+ * The point estimate is the MEDIAN read directly off that CDF (rank method):
+ * walk up the cumulative probabilities until they cross 50% and interpolate
+ * within the bucket where the crossing happens. No distribution shape is
+ * assumed for anything interior. The published band is P10..P90 read the same
+ * way. When a requested percentile falls inside an OPEN-ENDED outer bucket the
+ * books contain no information about how far out it lies, so an exponential
+ * tail matched to the adjacent bucket's density supplies a number, and the
+ * result is flagged (`valueBasis` / `p10Basis` / `p90Basis` = "tail") so
+ * consumers can decide whether to show it. Markets struck so that the mass
+ * stays between the outer boundaries never need the tail model at all.
+ *
+ * `confidence` per bucket is (1 - spread) * min(1, n / median(n)) with n the
+ * thinner side's committed dollars, standardised against the market's own
+ * depth so no external constant is needed. It does not move the median; it is
+ * published as book quality and drives warnings.
+ *
+ * @module
+ */
+
+// Translated from truflation/prediction-bots @ main 21fe4f3 (PR #37), upstream
+// path market-maker-bot/src/market_maker_bot/forecast.py, by way of the
+// byte-identical mirror in trufnetwork/sdk-py (src/trufnetwork_sdk_py/forecast.py).
+//
+// sdk-py can keep a verbatim copy and re-sync with a diff. TypeScript cannot, so
+// this is a hand translation and drift has to be caught by BEHAVIOUR instead:
+// forecast.test.ts and forecastDepth.test.ts are ports of the upstream suites,
+// including the frozen live NVDA book, and are the contract that keeps the two
+// SDKs agreeing. Change the algorithm upstream first, then port it here and
+// re-run both suites.
+//
+// Verified against sdk-py over 39 shared cases (best-quote and depth paths,
+// tails, the discrete fallback, dutch books, dust griefing, the frozen NVDA
+// book) and against a live mainnet market, where value, p10, p90, margin and
+// sigma all came back bit-identical.
+//
+// The residual is ~1e-16, worst case 6.5 ULP, and it has one cause: CPython
+// 3.12 gave `sum()` compensated (Neumaier) summation for floats, so the Python
+// sums are slightly MORE accurate than the plain left-to-right ones here.
+// Reproducing that would mean a compensated adder at every sum site, coupling
+// this file to a CPython implementation detail that upstream's source does not
+// state — it just says `sum(...)` — and making the translation harder to read
+// against the original, which is the whole maintenance strategy. Not worth it
+// for a difference fourteen orders of magnitude below the published margin of
+// error.
+//
+// It is not purely invisible: a sum landing within 1e-16 of a rounding boundary
+// can move the last digit of a warning STRING (a live book read 1.0725 in
+// Python and 1.0724999999999998 here, printing "1.073" against "1.072"). The
+// forecast numbers are unaffected. If a re-verification reports differences at
+// 1e-16, or a warning digit off by one, this is why.
+//
+// One deliberate omission: upstream still carries `_fit_normal`, the
+// weighted-least-squares normal fit on the probit scale that the rank method
+// replaced. It is unreachable there — nothing calls it — so it is not
+// translated, which also spares this file an inverse-normal CDF that JavaScript
+// has no standard-library answer for. If it is ever wired back up upstream, it
+// has to be written here from scratch, not ported.
+
+/** A bracket at least this wide contributes essentially nothing. */
+const MIN_CONFIDENCE = 1e-3;
+
+/**
+ * Half-spread used to complete a one-sided quote when the market gives us
+ * nothing better. Bounds keep a pathological book from imputing a silly step.
+ */
+const DEFAULT_HALF_SPREAD = 0.06;
+const MIN_HALF_SPREAD = 0.01;
+const MAX_HALF_SPREAD = 0.2;
+
+/**
+ * A quote below this notional is treated as absent. Size does not enter the
+ * forecast itself, so without a floor a single tiny order at a silly price moves
+ * the published number as much as a real one: one 90c bid on a dead tail shifted
+ * a bimodal market by 8 units, for 90c of risk. Only applied when sizes are
+ * supplied; callers that pass none keep the unfiltered behaviour.
+ */
+export const MIN_QUOTE_NOTIONAL_CENT_SHARES = 100;
+
+/**
+ * The buckets are mutually exclusive and exhaustive, so the asks must cost at
+ * least 1 and the bids must not pay more than 1. Outside these, someone is
+ * giving money away. Warned on rather than normalised silently.
+ */
+const DUTCH_BOOK_TOLERANCE = 0.02;
+
+/**
+ * Depth path only. A side whose ENTIRE ladder holds less than this many dollars
+ * is treated as absent: with the full book summed, dust cannot hide in front of
+ * a real order, so a small floor is enough to make sub-dollar griefing quotes
+ * weightless. Tunable.
+ */
+export const DEPTH_MIN_SIDE_NOTIONAL_USD = 5.0;
+
+/**
+ * Disclosure threshold only, never part of the math: a market whose books hold
+ * less than this in total gets a warning attached, because relative
+ * standardisation cannot see absolute poverty.
+ */
+export const LOW_TOTAL_NOTIONAL_WARN_USD = 50.0;
+
+/**
+ * A second density peak only counts as real multimodality if it reaches this
+ * fraction of the tallest peak; below it is quote noise.
+ */
+export const PEAK_PROMINENCE = 0.2;
+
+/** Where a percentile came from, and therefore how far to trust it. */
+export type ForecastBasis = "interior" | "tail" | "unresolved";
+
+/** How the point estimate was produced. */
+export type ForecastMethod = "rank" | "discrete";
+
+/** One resting level: price in cents (positive, 1-99), size in shares. */
+export interface BookLevel {
+  /** Price in cents, positive, 1-99. */
+  price: number;
+  /** Size in shares. */
+  size: number;
+}
+
+/**
+ * One bucket's bounds and its best two-sided quote, in cents.
+ *
+ * `lower`/`upper` are `null` for the open-ended outer buckets. Prices are the
+ * positive 1-99 cent convention for the bucket's YES side; `null` (or omitted)
+ * means no resting order on that side.
+ */
+export interface BucketBook {
+  /** Inclusive lower bound, `null` when the bucket is open below. */
+  lower: number | null;
+  /** Exclusive upper bound, `null` when the bucket is open above. */
+  upper: number | null;
+  /** Best bid in cents, `null`/omitted when nothing rests on the bid. */
+  bestBid?: number | null;
+  /** Best ask in cents, `null`/omitted when nothing rests on the ask. */
+  bestAsk?: number | null;
+  /** The bucket's market id, carried through to the result. */
+  queryId?: number | null;
+  /** Shares at the best bid. Supply it to enable the dust floor. */
+  bidSize?: number | null;
+  /** Shares at the best ask. Supply it to enable the dust floor. */
+  askSize?: number | null;
+}
+
+/**
+ * One bucket's FULL ladders on all four sides.
+ *
+ * The YES and NO books are consolidated inside this module because the
+ * inversion is executable, not merely informative. Verified on testnet
+ * (2026-08-03): the protocol's fill hierarchy matches EXACT inverses. A resting
+ * BUY NO at p mint-matches an incoming BUY YES at 100-p (one pair minted for
+ * $1), and a resting SELL NO at p burn-matches an incoming SELL YES at 100-p
+ * (one pair merged for $1). So:
+ *
+ *     consolidated bids = yesBids + (100 - p for every NO ask)
+ *     consolidated asks = yesAsks + (100 - p for every NO bid)
+ *
+ * both sides hittable at exactly the inverted price. There is no
+ * price-improvement crossing: near-inverses (sums other than 100) rest.
+ */
+export interface BucketDepth {
+  /** Inclusive lower bound, `null` when the bucket is open below. */
+  lower: number | null;
+  /** Exclusive upper bound, `null` when the bucket is open above. */
+  upper: number | null;
+  /** Resting YES buy orders, best first or unsorted. */
+  yesBids?: readonly BookLevel[];
+  /** Resting YES sell orders. */
+  yesAsks?: readonly BookLevel[];
+  /** Resting NO buy orders; these become executable YES asks. */
+  noBids?: readonly BookLevel[];
+  /** Resting NO sell orders; these become executable YES bids. */
+  noAsks?: readonly BookLevel[];
+  /** The bucket's market id, carried through to the result. */
+  queryId?: number | null;
+}
+
+/** What one bucket's book implies about its probability. */
+export interface BucketEstimate {
+  queryId: number | null;
+  lower: number | null;
+  upper: number | null;
+  /** Normalised; sums to 1 across the market. */
+  probability: number;
+  /** Before normalisation. */
+  rawProbability: number;
+  /** 0 = no usable quote, 1 = tight two-sided. */
+  confidence: number;
+  oneSided: boolean;
+  quoted: boolean;
+}
+
+/**
+ * The single value a market's order books imply.
+ *
+ * `value` is the MEDIAN of the implied distribution. `p10`/`p90` are the
+ * published band. Each carries a basis flag: "interior" means it was read
+ * between real strikes with no shape assumption; "tail" means it fell inside an
+ * open-ended outer bucket and rests on the exponential tail model; "unresolved"
+ * means the market has too few strikes to place it at all.
+ *
+ * `marginOfError` is kept for downstream compatibility as half the P10..P90
+ * band; `sigma` as the band scaled to a normal-equivalent standard deviation
+ * (band / 2.5631). Prefer the quantiles directly.
+ */
+export interface MarketForecast {
+  /** The median of the implied distribution. */
+  value: number;
+  /** Half the P10..P90 band. NOT a standard error — see the class note. */
+  marginOfError: number;
+  /** The band scaled to a normal-equivalent standard deviation. */
+  sigma: number;
+  method: ForecastMethod;
+  buckets: BucketEstimate[];
+  warnings: string[];
+  p10: number | null;
+  p90: number | null;
+  valueBasis: ForecastBasis;
+  p10Basis: ForecastBasis;
+  p90Basis: ForecastBasis;
+  multimodal: boolean;
+  nPeaks: number;
+  /** `value - marginOfError`. */
+  low: number;
+  /** `value + marginOfError`. */
+  high: number;
+}
+
+/** The flat form of a {@link MarketForecast}, for SDKs and the indexer. */
+export interface MarketForecastJSON {
+  value: number;
+  valueBasis: ForecastBasis;
+  p10: number | null;
+  p90: number | null;
+  p10Basis: ForecastBasis;
+  p90Basis: ForecastBasis;
+  marginOfError: number;
+  low: number;
+  high: number;
+  sigma: number;
+  method: ForecastMethod;
+  multimodal: boolean;
+  probabilities: number[];
+  warnings: string[];
+}
+
+/** Flat form for SDKs and the indexer. */
+export function forecastToJSON(forecast: MarketForecast): MarketForecastJSON {
+  return {
+    value: forecast.value,
+    valueBasis: forecast.valueBasis,
+    p10: forecast.p10,
+    p90: forecast.p90,
+    p10Basis: forecast.p10Basis,
+    p90Basis: forecast.p90Basis,
+    marginOfError: forecast.marginOfError,
+    low: forecast.low,
+    high: forecast.high,
+    sigma: forecast.sigma,
+    method: forecast.method,
+    multimodal: forecast.multimodal,
+    probabilities: forecast.buckets.map((b) => b.probability),
+    warnings: [...forecast.warnings],
+  };
+}
+
+// ============================================
+// Quote helpers
+// ============================================
+
+/** Prices are cent-denominated; keep the inverted ones off float dust. */
+function round4(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}
+
+/**
+ * Resolve an exact `.5` tie to even, the way Python's format spec does.
+ *
+ * `toFixed` breaks ties away from zero, so a 62.5% mass warning reads "63%" here
+ * and "62%" in sdk-py — a cosmetic split, but the warning strings are published
+ * output and the two SDKs are meant to agree character for character.
+ *
+ * Only exact ties are touched; everything else is handed back untouched for
+ * `toFixed` to round, which it already does correctly off the exact value. A
+ * real tie survives the scaling here: a double can only sit exactly on a decimal
+ * `.5` if it is dyadic, and a dyadic value times a power of ten is exact.
+ */
+function halfToEven(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  const scaled = value * factor;
+  const floor = Math.floor(scaled);
+  if (scaled - floor !== 0.5) return value;
+  return (floor % 2 === 0 ? floor : floor + 1) / factor;
+}
+
+/** Python's `f"{x:.Nf}"`. */
+function fixed(value: number, digits: number): string {
+  return halfToEven(value, digits).toFixed(digits);
+}
+
+/** Python's `f"{x:+.1f}"`. */
+function signed1(value: number): string {
+  return (value >= 0 ? "+" : "") + fixed(value, 1);
+}
+
+/** Python's `f"{x:,.0f}"`. */
+function grouped0(value: number): string {
+  return fixed(value, 0).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/**
+ * Drop a top-of-book quote too small to mean anything.
+ *
+ * LIMITATION: this only sees the best level. If a dust order is sitting in
+ * front of a real one, dropping it here marks the whole bucket unpriced rather
+ * than falling back to the real quote behind it, which can be worse than not
+ * filtering at all. Callers that hold the full book should instead pass the best
+ * level whose size clears the floor, and leave the size fields unset. This is a
+ * backstop, not the fix.
+ */
+function usableQuote(
+  price: number | null | undefined,
+  size: number | null | undefined
+): number | null {
+  if (price === null || price === undefined) return null;
+  if (size === null || size === undefined) return price;
+  return price * size >= MIN_QUOTE_NOTIONAL_CENT_SHARES ? price : null;
+}
+
+/** The bucket's best bid, or `null` when it is absent or below the dust floor. */
+export function usableBid(book: BucketBook): number | null {
+  return usableQuote(book.bestBid, book.bidSize);
+}
+
+/** The bucket's best ask, or `null` when it is absent or below the dust floor. */
+export function usableAsk(book: BucketBook): number | null {
+  return usableQuote(book.bestAsk, book.askSize);
+}
+
+/**
+ * The bucket's executable bid ladder: its YES bids plus every NO ask inverted
+ * to the YES price it is hittable at. Best (highest) first.
+ */
+export function consolidatedBids(depth: BucketDepth): BookLevel[] {
+  const levels: BookLevel[] = [];
+  for (const level of depth.yesBids ?? []) {
+    if (level.size > 0) levels.push(level);
+  }
+  for (const level of depth.noAsks ?? []) {
+    if (level.size > 0) {
+      levels.push({ price: round4(100 - level.price), size: level.size });
+    }
+  }
+  return levels.sort((a, b) => b.price - a.price);
+}
+
+/**
+ * The bucket's executable ask ladder: its YES asks plus every NO bid inverted
+ * to the YES price it is hittable at. Best (lowest) first.
+ */
+export function consolidatedAsks(depth: BucketDepth): BookLevel[] {
+  const levels: BookLevel[] = [];
+  for (const level of depth.yesAsks ?? []) {
+    if (level.size > 0) levels.push(level);
+  }
+  for (const level of depth.noBids ?? []) {
+    if (level.size > 0) {
+      levels.push({ price: round4(100 - level.price), size: level.size });
+    }
+  }
+  return levels.sort((a, b) => a.price - b.price);
+}
+
+/** The consolidated best quotes, for the spread and dutch-book helpers. */
+export function bestView(depth: BucketDepth): BucketBook {
+  const bids = consolidatedBids(depth);
+  const asks = consolidatedAsks(depth);
+  return {
+    lower: depth.lower,
+    upper: depth.upper,
+    bestBid: bids.length ? bids[0].price : null,
+    bestAsk: asks.length ? asks[0].price : null,
+    queryId: depth.queryId ?? null,
+  };
+}
+
+/**
+ * Half the market's median two-sided spread, as a probability.
+ *
+ * Used to complete one-sided quotes. A missing side is usually an artifact of
+ * the market maker's own quoting (no inventory to sell, or the self-cross guard
+ * suppressing a leg) rather than a statement about probability, so the other
+ * side is still informative once shifted by the spread this market actually
+ * trades.
+ */
+export function typicalHalfSpread(buckets: readonly BucketBook[]): number {
+  const spreads: number[] = [];
+  for (const b of buckets) {
+    const bid = b.bestBid;
+    const ask = b.bestAsk;
+    if (bid === null || bid === undefined) continue;
+    if (ask === null || ask === undefined) continue;
+    if (ask < bid) continue;
+    spreads.push((ask - bid) / 100);
+  }
+  if (!spreads.length) return DEFAULT_HALF_SPREAD;
+  spreads.sort((a, b) => a - b);
+  const mid = Math.floor(spreads.length / 2);
+  const median =
+    spreads.length % 2 ? spreads[mid] : (spreads[mid - 1] + spreads[mid]) / 2;
+  return Math.max(MIN_HALF_SPREAD, Math.min(median / 2, MAX_HALF_SPREAD));
+}
+
+/** What one bucket's best quote says, before normalisation. */
+export interface BucketQuoteEstimate {
+  /** `null` when the bucket is unquoted or crossed. NOT 0.5. */
+  probability: number | null;
+  confidence: number;
+  oneSided: boolean;
+  quoted: boolean;
+}
+
+/**
+ * Turn one bucket's best quote into a probability, confidence and flags.
+ *
+ * Two-sided is the easy case: the mid, with confidence from how tight the
+ * spread is.
+ *
+ * One-sided needs care. Treating a lone 1c bid as the midpoint of [0.01, 1.0]
+ * would call it a coin flip, which is badly wrong: on real mainnet books the
+ * open tail buckets are frequently bid-only at a penny, and the midpoint rule
+ * handed them 27% each and buried the actual distribution. The quoted side is
+ * the only real information, so we take it and step across by the market's own
+ * half-spread, then mark the confidence down.
+ *
+ * An unquoted bucket returns `null`. It is NOT 0.5: the caller assigns it the
+ * residual probability the quoted buckets leave behind, which is what the
+ * market actually implies about it.
+ */
+export function bucketProbability(
+  bestBid: number | null | undefined,
+  bestAsk: number | null | undefined,
+  halfSpread: number = DEFAULT_HALF_SPREAD
+): BucketQuoteEstimate {
+  const bid = bestBid ?? null;
+  const ask = bestAsk ?? null;
+  const quoted = bid !== null || ask !== null;
+  if (!quoted) {
+    return { probability: null, confidence: 0, oneSided: false, quoted: false };
+  }
+
+  const oneSided = bid === null || ask === null;
+
+  if (!oneSided) {
+    const lo = Math.max(0, Math.min(1, (bid as number) / 100));
+    const hi = Math.max(0, Math.min(1, (ask as number) / 100));
+    if (hi < lo) {
+      // Crossed book: bid above ask. Either stale, or free money. Keeping the
+      // midpoint at low confidence would still let the bogus probability enter
+      // the normalisation and shift every CDF point, because confidence only
+      // affects weighting. Treat it as unquoted so the caller can assign it the
+      // residual instead.
+      return { probability: null, confidence: 0, oneSided, quoted };
+    }
+    return {
+      probability: (lo + hi) / 2,
+      confidence: 1 - (hi - lo),
+      oneSided,
+      quoted,
+    };
+  }
+
+  let p =
+    bid !== null ? bid / 100 + halfSpread : (ask as number) / 100 - halfSpread;
+  p = Math.max(0, Math.min(1, p));
+  // Confidence of a two-sided book at this spread, halved: we inferred one side
+  // rather than observing it.
+  return {
+    probability: p,
+    confidence: Math.max(MIN_CONFIDENCE, (1 - 2 * halfSpread) / 2),
+    oneSided,
+    quoted,
+  };
+}
+
+// ============================================
+// Shared back half of the pipeline
+// ============================================
+
+/**
+ * Probability-weighted bucket midpoints, for when the rank read cannot run.
+ *
+ * The open tails have no midpoint, so they are represented by their finite edge
+ * pushed out by half the average interior width. Cruder than a rank read and
+ * biased toward the centre, which is why it is only a fallback.
+ */
+function discreteFallback(
+  estimates: readonly BucketEstimate[],
+  boundaries: readonly number[]
+): { value: number; sigma: number } {
+  const widths: number[] = [];
+  for (let i = 0; i + 1 < boundaries.length; i++) {
+    widths.push(boundaries[i + 1] - boundaries[i]);
+  }
+  const pad = widths.length
+    ? widths.reduce((a, b) => a + b, 0) / widths.length / 2
+    : 0;
+
+  const points: number[] = [];
+  const probs: number[] = [];
+  for (const est of estimates) {
+    if (est.lower === null && est.upper === null) continue;
+    let point: number;
+    if (est.lower === null) {
+      point = (est.upper as number) - pad;
+    } else if (est.upper === null) {
+      point = est.lower + pad;
+    } else {
+      point = (est.lower + est.upper) / 2;
+    }
+    points.push(point);
+    probs.push(est.probability);
+  }
+
+  const total = probs.reduce((a, b) => a + b, 0);
+  if (total <= 0 || !points.length) return { value: NaN, sigma: NaN };
+
+  const mean = points.reduce((acc, x, i) => acc + probs[i] * x, 0) / total;
+  const variance =
+    points.reduce((acc, x, i) => acc + probs[i] * (x - mean) ** 2, 0) / total;
+  return { value: mean, sigma: Math.sqrt(Math.max(variance, 0)) };
+}
+
+/**
+ * A margin of error for the discrete fallback.
+ *
+ * Publishing `sigma` here would be wrong: sigma is how uncertain the OUTCOME is,
+ * not how well the book pins our estimate. The fallback also represents each
+ * open tail by an invented point, so its centre is genuinely less trustworthy
+ * than a rank read. Scale sigma down by the number of buckets we could actually
+ * read, and floor it so a fallback can never claim to be tighter than a real
+ * read.
+ */
+function discreteMargin(
+  sigma: number,
+  estimates: readonly BucketEstimate[]
+): number {
+  const quoted = estimates.filter((e) => e.quoted).length || 1;
+  const conf =
+    estimates.reduce((acc, e) => acc + e.confidence, 0) /
+    Math.max(estimates.length, 1);
+  return (sigma * (1 - 0.5 * conf)) / Math.sqrt(quoted);
+}
+
+/**
+ * Mutually exclusive and exhaustive buckets bound the book.
+ *
+ * Buying YES in every bucket guarantees exactly 1, so the asks must sum to at
+ * least 1. Minting a pair in every bucket and selling all the YES also settles
+ * at 1, so the bids must not sum to more than 1. A violation is risk-free money
+ * against us.
+ */
+function dutchBookWarning(buckets: readonly BucketBook[]): string | null {
+  const asks = buckets.map(usableAsk);
+  const bids = buckets.map(usableBid);
+  if (asks.every((a) => a !== null)) {
+    const total = (asks as number[]).reduce((a, b) => a + b, 0) / 100;
+    if (total < 1 - DUTCH_BOOK_TOLERANCE) {
+      return (
+        `DUTCH BOOK: asks sum to ${fixed(total, 3)}; buying every bucket costs ` +
+        `${fixed(total, 3)} and settles at 1.000, a risk-free ` +
+        `${fixed((1 - total) * 100, 1)}c per dollar against us`
+      );
+    }
+  }
+  if (bids.every((b) => b !== null)) {
+    const total = (bids as number[]).reduce((a, b) => a + b, 0) / 100;
+    if (total > 1 + DUTCH_BOOK_TOLERANCE) {
+      return (
+        `DUTCH BOOK: bids sum to ${fixed(total, 3)}; minting and selling every ` +
+        `bucket pays ${fixed(total, 3)} against a cost of 1.000, a risk-free ` +
+        `${fixed((total - 1) * 100, 1)}c per dollar against us`
+      );
+    }
+  }
+  return null;
+}
+
+/**
+ * Percentile `q` read directly off the piecewise-linear implied CDF.
+ *
+ * Interior crossings interpolate between real strikes and assume nothing beyond
+ * uniform density within the bucket. A crossing inside an open-ended outer
+ * bucket needs a shape for the tail; we use an exponential decay matched to the
+ * adjacent interior bucket's density, and flag the result "tail" so consumers
+ * know it rests on that assumption. With fewer than two boundaries there is no
+ * interior at all and no density to anchor a tail, so the answer is unresolved.
+ */
+function rankQuantile(
+  bounds: readonly number[],
+  probs: readonly number[],
+  q: number
+): { value: number | null; basis: ForecastBasis } {
+  const k = probs.length;
+  const cum: number[] = [];
+  let run = 0;
+  for (let i = 0; i < k - 1; i++) {
+    run += probs[i];
+    cum.push(run);
+  }
+  if (bounds.length < 2) return { value: null, basis: "unresolved" };
+
+  for (let i = 1; i < k - 1; i++) {
+    // interior buckets
+    const loC = cum[i - 1];
+    const hiC = cum[i];
+    if (loC <= q && q <= hiC) {
+      const loB = bounds[i - 1];
+      const hiB = bounds[i];
+      if (hiC <= loC) return { value: (loB + hiB) / 2, basis: "interior" };
+      const frac = (q - loC) / (hiC - loC);
+      return { value: loB + frac * (hiB - loB), basis: "interior" };
+    }
+  }
+
+  const widths: number[] = [];
+  for (let i = 0; i + 1 < bounds.length; i++) {
+    widths.push(bounds[i + 1] - bounds[i]);
+  }
+
+  if (q < cum[0]) {
+    // lower open tail
+    const dens = widths[0] > 0 ? probs[1] / widths[0] : 0;
+    if (dens <= 0 || cum[0] <= 0) return { value: null, basis: "unresolved" };
+    const lam = dens / cum[0];
+    return { value: bounds[0] + Math.log(q / cum[0]) / lam, basis: "tail" };
+  }
+
+  // upper open tail
+  const upperMass = probs[k - 1];
+  const dens = widths[widths.length - 1] > 0 ? probs[k - 2] / widths[widths.length - 1] : 0;
+  if (dens <= 0 || upperMass <= 0) return { value: null, basis: "unresolved" };
+  const lam = dens / upperMass;
+  return {
+    value:
+      bounds[bounds.length - 1] -
+      Math.log(Math.max(1 - q, 1e-12) / upperMass) / lam,
+    basis: "tail",
+  };
+}
+
+/**
+ * Prominent local maxima of the interior density profile.
+ *
+ * A peak only counts if it reaches {@link PEAK_PROMINENCE} of the tallest one,
+ * so a penny-noise bump next to a 96% bucket does not read as bimodality. Open
+ * tails carry no density profile, so tail-heavy bimodality is seen through the
+ * interior buckets adjacent to the tails.
+ */
+function countPeaks(bounds: readonly number[], probs: readonly number[]): number {
+  const dens: number[] = [];
+  for (let i = 0; i + 1 < bounds.length; i++) {
+    const w = bounds[i + 1] - bounds[i];
+    dens.push(w > 0 ? probs[i + 1] / w : 0);
+  }
+  if (!dens.length) return 1;
+  const top = Math.max(...dens);
+  if (top <= 0) return 1;
+  let peaks = 0;
+  for (let i = 0; i < dens.length; i++) {
+    const d = dens[i];
+    const isMax =
+      (i === 0 || d > dens[i - 1]) &&
+      (i === dens.length - 1 || d >= dens[i + 1]);
+    if (isMax && d >= PEAK_PROMINENCE * top) peaks += 1;
+  }
+  return Math.max(peaks, 1);
+}
+
+/** One bucket's identity, as `assemble` needs it. */
+interface BucketMeta {
+  lower: number | null;
+  upper: number | null;
+  queryId: number | null;
+}
+
+function buildForecast(
+  value: number,
+  marginOfError: number,
+  sigma: number,
+  method: ForecastMethod,
+  buckets: BucketEstimate[],
+  warnings: string[],
+  extra: Partial<MarketForecast> = {}
+): MarketForecast {
+  return {
+    value,
+    marginOfError,
+    sigma,
+    method,
+    buckets,
+    warnings,
+    p10: null,
+    p90: null,
+    valueBasis: "interior",
+    p10Basis: "interior",
+    p90Basis: "interior",
+    multimodal: false,
+    nPeaks: 1,
+    low: value - marginOfError,
+    high: value + marginOfError,
+    ...extra,
+  };
+}
+
+/**
+ * Shared back half of the pipeline: normalise the per-bucket estimates, build
+ * the implied CDF, read the percentiles off it, or fall back.
+ *
+ * `bidsCents` is each bucket's best bid, used only to bound what an unpriced
+ * bucket could claim.
+ */
+function assemble(
+  meta: readonly BucketMeta[],
+  bidsCents: readonly (number | null)[],
+  raw: readonly (number | null)[],
+  confs: readonly number[],
+  oneSidedFlags: readonly boolean[],
+  quotedFlags: readonly boolean[],
+  warnings: string[]
+): MarketForecast | null {
+  if (!quotedFlags.some(Boolean)) return null;
+
+  const nMissing = raw.filter((p) => p === null).length;
+  const nUnquoted = quotedFlags.filter((q) => !q).length;
+  const nCrossed = nMissing - nUnquoted;
+  if (nUnquoted) {
+    warnings.push(`${nUnquoted} of ${meta.length} buckets unquoted`);
+  }
+  if (nCrossed) {
+    warnings.push(
+      `${nCrossed} bucket(s) crossed (bid above ask); treated as unpriced`
+    );
+  }
+  if (oneSidedFlags.some(Boolean)) {
+    warnings.push(
+      `${oneSidedFlags.filter(Boolean).length} bucket(s) one-sided; ` +
+        `margin of error widened`
+    );
+  }
+
+  const quotedTotal = raw.reduce<number>((acc, p) => acc + (p ?? 0), 0);
+  if (quotedTotal <= 0) return null;
+  if (Math.abs(quotedTotal - 1) > DUTCH_BOOK_TOLERANCE) {
+    // Independent books never sum to exactly 1. Report the SIGNED deviation
+    // rather than a wide dead band: the direction says whether the book is over-
+    // or under-priced, and a wide window hides real boxes.
+    warnings.push(
+      `bucket mids sum to ${fixed(quotedTotal, 3)} ` +
+        `(${signed1((quotedTotal - 1) * 100)}c per dollar) before normalising`
+    );
+  }
+
+  let filled = [...raw];
+  if (nMissing) {
+    // An unpriced bucket is UNKNOWN, not impossible. Its probability is bounded
+    // above by whatever the other buckets' BIDS do not already claim, since bids
+    // are a lower bound on their true probabilities. Take the midpoint of that
+    // interval. Asserting zero is a strong claim the book never made.
+    let bidClaim = 0;
+    for (let i = 0; i < raw.length; i++) {
+      if (raw[i] !== null) bidClaim += (bidsCents[i] ?? 0) / 100;
+    }
+    const headroom = Math.max(0, 1 - bidClaim);
+    const est = headroom / (2 * nMissing);
+    filled = raw.map((p) => (p === null ? est : p));
+  }
+
+  const total = filled.reduce<number>((acc, p) => acc + (p ?? 0), 0);
+  if (total <= 0) return null;
+  const probs = filled.map((p) => (p ?? 0) / total);
+
+  const estimates: BucketEstimate[] = meta.map((m, i) => ({
+    queryId: m.queryId,
+    lower: m.lower,
+    upper: m.upper,
+    probability: probs[i],
+    rawProbability: raw[i] ?? 0,
+    confidence: confs[i],
+    oneSided: oneSidedFlags[i],
+    quoted: quotedFlags[i],
+  }));
+
+  const bounds = meta
+    .slice(0, -1)
+    .map((m) => m.upper)
+    .filter((u): u is number => u !== null);
+
+  if (bounds.length !== meta.length - 1) {
+    warnings.push("bucket bounds incomplete; falling back to discrete estimate");
+    const { value, sigma } = discreteFallback(estimates, bounds);
+    if (Number.isNaN(value)) return null;
+    return buildForecast(
+      value,
+      discreteMargin(sigma, estimates),
+      sigma,
+      "discrete",
+      estimates,
+      warnings
+    );
+  }
+
+  // Rank method: read the percentiles straight off the implied CDF.
+  const med = rankQuantile(bounds, probs, 0.5);
+  const p10 = rankQuantile(bounds, probs, 0.1);
+  const p90 = rankQuantile(bounds, probs, 0.9);
+
+  if (med.value === null) {
+    warnings.push(
+      "median unresolvable from these strikes; falling back to discrete estimate"
+    );
+    const { value, sigma } = discreteFallback(estimates, bounds);
+    if (Number.isNaN(value)) return null;
+    return buildForecast(
+      value,
+      discreteMargin(sigma, estimates),
+      sigma,
+      "discrete",
+      estimates,
+      warnings
+    );
+  }
+
+  if (med.basis === "tail") {
+    const outside = probs[0] >= 0.5 ? probs[0] : probs[probs.length - 1];
+    warnings.push(
+      `median lies beyond the outer strikes (${fixed(outside * 100, 0)}% of mass ` +
+        `in an open-ended bucket); value depends on the assumed tail shape`
+    );
+  }
+  for (const [name, basis] of [
+    ["p10", p10.basis],
+    ["p90", p90.basis],
+  ] as const) {
+    if (basis === "tail") {
+      warnings.push(`${name} falls in an open tail; tail-model dependent`);
+    } else if (basis === "unresolved") {
+      warnings.push(`${name} unresolvable from these strikes`);
+    }
+  }
+
+  const nPeaks = countPeaks(bounds, probs);
+  const multimodal = nPeaks >= 2;
+  if (multimodal) {
+    warnings.push(
+      `market shows ${nPeaks} probability clusters; a single point ` +
+        `forecast misrepresents it, publish the clusters instead`
+    );
+  }
+
+  let margin: number;
+  let sigma: number;
+  if (p10.value !== null && p90.value !== null) {
+    const band = Math.max(p90.value - p10.value, 0);
+    margin = band / 2;
+    sigma = band / 2.5631; // P10..P90 of a normal spans 2.5631 sigma
+  } else {
+    margin = 0;
+    sigma = 0;
+    warnings.push("band unresolvable; margin and sigma reported as 0");
+  }
+
+  return buildForecast(
+    med.value,
+    margin,
+    sigma,
+    "rank",
+    estimates,
+    warnings,
+    {
+      p10: p10.value,
+      p90: p90.value,
+      valueBasis: med.basis,
+      p10Basis: p10.basis,
+      p90Basis: p90.basis,
+      multimodal,
+      nPeaks,
+    }
+  );
+}
+
+// ============================================
+// Entry points
+// ============================================
+
+/**
+ * Collapse one market's bucket books into a single implied value, from best
+ * quotes only.
+ *
+ * Buckets must be supplied in ascending order and span the whole line, with the
+ * first open below and the last open above. Returns `null` when the book carries
+ * no usable information at all. When full ladders are available, prefer
+ * {@link forecastFromDepth}, which weights by committed notional.
+ */
+export function forecastFromBuckets(
+  buckets: readonly BucketBook[]
+): MarketForecast | null {
+  const warnings: string[] = [];
+
+  if (buckets.length < 2) return null;
+
+  const half = typicalHalfSpread(buckets);
+
+  const dutch = dutchBookWarning(buckets);
+  if (dutch) warnings.push(dutch);
+
+  const raw: (number | null)[] = [];
+  const confs: number[] = [];
+  const oneSidedFlags: boolean[] = [];
+  const quotedFlags: boolean[] = [];
+  for (const b of buckets) {
+    const est = bucketProbability(usableBid(b), usableAsk(b), half);
+    raw.push(est.probability);
+    confs.push(est.confidence);
+    oneSidedFlags.push(est.oneSided);
+    quotedFlags.push(est.quoted);
+  }
+
+  return assemble(
+    buckets.map((b) => ({
+      lower: b.lower,
+      upper: b.upper,
+      queryId: b.queryId ?? null,
+    })),
+    buckets.map(usableBid),
+    raw,
+    confs,
+    oneSidedFlags,
+    quotedFlags,
+    warnings
+  );
+}
+
+/**
+ * `(vwapCents, notionalUsd, shares)` over a full ladder.
+ *
+ * The full-ladder VWAP no longer prices anything (see `walkPrice`); dollars are
+ * the currency for confidence and the dust floors, since posting many shares of
+ * a cheap side is not the same commitment as posting the same dollars.
+ */
+function sideStats(levels: readonly BookLevel[]): {
+  vwapCents: number;
+  notionalUsd: number;
+  shares: number;
+} {
+  let centShares = 0;
+  let shares = 0;
+  for (const l of levels) {
+    centShares += l.price * l.size;
+    shares += l.size;
+  }
+  return {
+    vwapCents: centShares / shares,
+    notionalUsd: centShares / 100,
+    shares,
+  };
+}
+
+/**
+ * Dollar-weighted price of executing `targetUsd` from the touch.
+ *
+ * Walk the ladder best-first, consuming each level's own notional until the
+ * target is reached; the last level fills partially. Each committed dollar
+ * carries the same weight regardless of the price it rests at, which is the
+ * whole point: per-dollar influence must not depend on denomination, or penny
+ * ladders (25 shares per dollar at 4c) out-vote real money.
+ *
+ * Callers guarantee the ladder holds at least `targetUsd` in total (the side
+ * floor); if it somehow does not, the walk prices what is there.
+ */
+function walkPrice(levels: readonly BookLevel[], targetUsd: number): number {
+  let remaining = targetUsd * 100; // cent-shares
+  let weighted = 0;
+  let taken = 0;
+  for (const l of levels) {
+    if (remaining <= 0) break;
+    const take = Math.min(l.price * l.size, remaining);
+    weighted += take * l.price;
+    taken += take;
+    remaining -= take;
+  }
+  return weighted / taken;
+}
+
+/** What one bucket's full ladders say, before normalisation. */
+export interface BucketDepthEstimate {
+  /** `null` when the bucket is unquoted or crossed at the consolidated touch. */
+  probability: number | null;
+  /** The spread component of confidence. */
+  quality: number;
+  /** Committed dollars backing the estimate. */
+  notionalUsd: number;
+  oneSided: boolean;
+  quoted: boolean;
+}
+
+/**
+ * One bucket's implied probability from its full consolidated ladders.
+ *
+ * The probability is the midpoint of the two executable walk prices: the
+ * dollar-weighted price of selling {@link DEPTH_MIN_SIDE_NOTIONAL_USD} into the
+ * consolidated bids and of buying the same from the consolidated asks, clamped
+ * into [best bid, best ask]. A book only pins the truth to that interval, so the
+ * estimate must be a selection from it; depth beyond the first walk dollars is
+ * inventory, not opinion, and moves confidence only.
+ *
+ * This replaced a full-book share-weighted microprice, which let cheap ladders
+ * out-vote real money (a dollar at 4c is 25 shares, at 30c it is 3) and on live
+ * books pushed every sub-50c bucket above its own best ask (prediction-bots
+ * issue #36). Ladder imbalance moves the walk mid not at all: on this venue all
+ * resting flow is the market maker's own, so imbalance carries no information
+ * and would only be a free manipulation lever.
+ *
+ * `quality` is the spread component of confidence: (1 - spread) two-sided,
+ * halved for a one-sided book whose missing side was inferred. `notionalUsd` is
+ * the committed dollars backing the estimate: the THINNER side when both exist,
+ * the quoted side otherwise. The caller standardises notional against the
+ * market's own median depth to finish the confidence; no external constant is
+ * involved.
+ *
+ * Sides whose whole ladder holds under {@link DEPTH_MIN_SIDE_NOTIONAL_USD} are
+ * treated as absent: with the full book summed, dust cannot hide in front of a
+ * real order. Trades are deliberately NOT used: resting depth is live, at-risk
+ * capital, and the venue's only taker is a designed noise trader.
+ */
+export function bucketEstimateFromDepth(
+  depth: BucketDepth,
+  halfSpread: number = DEFAULT_HALF_SPREAD
+): BucketDepthEstimate {
+  let bids = consolidatedBids(depth);
+  let asks = consolidatedAsks(depth);
+  let bidNotional: number | null = null;
+  let askNotional: number | null = null;
+
+  if (bids.length) {
+    const stats = sideStats(bids);
+    bidNotional = stats.notionalUsd;
+    if (bidNotional < DEPTH_MIN_SIDE_NOTIONAL_USD) {
+      bids = [];
+      bidNotional = null;
+    }
+  }
+  if (asks.length) {
+    const stats = sideStats(asks);
+    askNotional = stats.notionalUsd;
+    if (askNotional < DEPTH_MIN_SIDE_NOTIONAL_USD) {
+      asks = [];
+      askNotional = null;
+    }
+  }
+
+  const quoted = bids.length > 0 || asks.length > 0;
+  if (!quoted) {
+    return {
+      probability: null,
+      quality: 0,
+      notionalUsd: 0,
+      oneSided: false,
+      quoted: false,
+    };
+  }
+  const oneSided = !(bids.length && asks.length);
+
+  if (!oneSided) {
+    const bestBid = bids[0].price;
+    const bestAsk = asks[0].price;
+    if (bestBid >= bestAsk) {
+      // Crossed at the consolidated touch: stale or free money.
+      return {
+        probability: null,
+        quality: 0,
+        notionalUsd: 0,
+        oneSided,
+        quoted,
+      };
+    }
+    const walkBid = walkPrice(bids, DEPTH_MIN_SIDE_NOTIONAL_USD);
+    const walkAsk = walkPrice(asks, DEPTH_MIN_SIDE_NOTIONAL_USD);
+    let p = (walkBid + walkAsk) / 2;
+    p = Math.max(bestBid, Math.min(bestAsk, p)) / 100;
+    const spread = (bestAsk - bestBid) / 100;
+    return {
+      probability: Math.max(0, Math.min(1, p)),
+      quality: Math.max(1 - spread, MIN_CONFIDENCE),
+      notionalUsd: Math.min(bidNotional as number, askNotional as number),
+      oneSided,
+      quoted,
+    };
+  }
+
+  let p: number;
+  let notional: number;
+  if (bids.length) {
+    p = walkPrice(bids, DEPTH_MIN_SIDE_NOTIONAL_USD) / 100 + halfSpread;
+    notional = bidNotional as number;
+  } else {
+    p = walkPrice(asks, DEPTH_MIN_SIDE_NOTIONAL_USD) / 100 - halfSpread;
+    notional = askNotional as number;
+  }
+  const quality = (1 - 2 * halfSpread) / 2;
+  return {
+    probability: Math.max(0, Math.min(1, p)),
+    quality: Math.max(quality, MIN_CONFIDENCE),
+    notionalUsd: notional,
+    oneSided,
+    quoted,
+  };
+}
+
+/**
+ * Collapse one market's bucket books into a single implied value, using FULL YES
+ * and NO ladders weighted by committed notional.
+ *
+ * This is the preferred entry point. The YES/NO consolidation happens here, per
+ * bucket, because the inversion is executable on this venue (exact inverse
+ * mint/burn matching, verified on testnet 2026-08-03), so callers should not
+ * have to know the rule.
+ */
+export function forecastFromDepth(
+  buckets: readonly BucketDepth[]
+): MarketForecast | null {
+  const warnings: string[] = [];
+
+  if (buckets.length < 2) return null;
+
+  const views = buckets.map(bestView);
+  const half = typicalHalfSpread(views);
+
+  const dutch = dutchBookWarning(views);
+  if (dutch) warnings.push(dutch);
+
+  const raw: (number | null)[] = [];
+  const qualities: number[] = [];
+  const notionals: number[] = [];
+  const oneSidedFlags: boolean[] = [];
+  const quotedFlags: boolean[] = [];
+  for (const b of buckets) {
+    const est = bucketEstimateFromDepth(b, half);
+    raw.push(est.probability);
+    qualities.push(est.quality);
+    notionals.push(est.notionalUsd);
+    oneSidedFlags.push(est.oneSided);
+    quotedFlags.push(est.quoted);
+  }
+
+  // Confidence = quality * min(1, n / median(n)), the market standardised
+  // against its own depth. Median rather than max or sum so a single whale
+  // bucket cannot crush its siblings' credibility.
+  const pricedN = notionals
+    .filter((n, i) => raw[i] !== null && n > 0)
+    .sort((a, b) => a - b);
+  let medN = 0;
+  if (pricedN.length) {
+    const mid = Math.floor(pricedN.length / 2);
+    medN =
+      pricedN.length % 2 ? pricedN[mid] : (pricedN[mid - 1] + pricedN[mid]) / 2;
+  }
+  const confs: number[] = raw.map((p, i) => {
+    if (p === null) return 0;
+    if (medN > 0) {
+      return Math.max(
+        qualities[i] * Math.min(1, notionals[i] / medN),
+        MIN_CONFIDENCE
+      );
+    }
+    return qualities[i];
+  });
+
+  // Disclosure, never math: relative standardisation cannot see absolute
+  // poverty, so a market that is thin EVERYWHERE gets a visible caveat.
+  let totalUsd = 0;
+  for (const b of buckets) {
+    for (const side of [consolidatedBids(b), consolidatedAsks(b)]) {
+      if (side.length) totalUsd += sideStats(side).notionalUsd;
+    }
+  }
+  if (totalUsd < LOW_TOTAL_NOTIONAL_WARN_USD) {
+    warnings.push(
+      `total resting notional only $${grouped0(totalUsd)} across all buckets`
+    );
+  }
+
+  return assemble(
+    buckets.map((b) => ({
+      lower: b.lower,
+      upper: b.upper,
+      queryId: b.queryId ?? null,
+    })),
+    views.map((v) => v.bestBid ?? null),
+    raw,
+    confs,
+    oneSidedFlags,
+    quotedFlags,
+    warnings
+  );
+}

--- a/src/util/forecast.ts
+++ b/src/util/forecast.ts
@@ -577,9 +577,13 @@ function discreteFallback(
  * Publishing `sigma` here would be wrong: sigma is how uncertain the OUTCOME is,
  * not how well the book pins our estimate. The fallback also represents each
  * open tail by an invented point, so its centre is genuinely less trustworthy
- * than a rank read. Scale sigma down by the number of buckets we could actually
- * read, and floor it so a fallback can never claim to be tighter than a real
- * read.
+ * than a rank read, so sigma is scaled down by the number of buckets we could
+ * actually read.
+ *
+ * Upstream's docstring also claims a floor "so a fallback can never claim to be
+ * tighter than a real fit". No floor is implemented there, and adding one here
+ * would silently diverge from sdk-py, so the claim is dropped rather than the
+ * behaviour changed. Worth raising upstream.
  */
 function discreteMargin(
   sigma: number,

--- a/src/util/forecastDepth.test.ts
+++ b/src/util/forecastDepth.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Tests for the depth-weighted forecast path.
+ *
+ * The depth path consolidates the YES and NO ladders inside the module (the
+ * inversion is executable via exact-inverse mint/burn matching, verified on
+ * testnet 2026-08-03) and weights each bucket by committed notional rather than
+ * reading best quotes alone.
+ *
+ * Ported case-for-case from sdk-py's tests/test_forecast_depth.py.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  BookLevel,
+  BucketBook,
+  BucketDepth,
+  bucketEstimateFromDepth,
+  consolidatedAsks,
+  consolidatedBids,
+  forecastFromBuckets,
+  forecastFromDepth,
+} from "./forecast";
+
+// MSFT-shaped bounds, as on mainnet.
+const BOUNDS: [number | null, number | null][] = [
+  [null, 4.04],
+  [4.04, 4.33],
+  [4.33, 4.62],
+  [4.62, 4.92],
+  [4.92, null],
+];
+
+const round4 = (x: number) => Math.round(x * 1e4) / 1e4;
+
+/** Symmetric YES ladders plus the exact NO mirror our MM would post. */
+function ladder(mid: number, size = 100, levels = 3, spread = 2, step = 1) {
+  const yesBids: BookLevel[] = [];
+  const yesAsks: BookLevel[] = [];
+  for (let k = 0; k < levels; k++) {
+    yesBids.push({ price: round4(mid - spread / 2 - k * step), size });
+    yesAsks.push({ price: round4(mid + spread / 2 + k * step), size });
+  }
+  const noBids = yesAsks.map((l) => ({ price: round4(100 - l.price), size: l.size }));
+  const noAsks = yesBids.map((l) => ({ price: round4(100 - l.price), size: l.size }));
+  return { yesBids, yesAsks, noBids, noAsks };
+}
+
+function build(
+  mids: (number | null)[],
+  sizes?: number[],
+  bounds: [number | null, number | null][] = BOUNDS
+): BucketDepth[] {
+  return bounds.map(([lower, upper], i) => {
+    const mid = mids[i];
+    if (mid === null || mid === undefined) return { lower, upper };
+    return { lower, upper, ...ladder(mid, sizes ? sizes[i] : 100) };
+  });
+}
+
+describe("YES/NO consolidation", () => {
+  it("turns a NO bid into an executable ask", () => {
+    const asks = consolidatedAsks({
+      lower: null,
+      upper: 4.04,
+      noBids: [{ price: 83, size: 50 }],
+    });
+    expect(asks).toHaveLength(1);
+    expect(asks[0].price).toBeCloseTo(17, 10);
+    expect(asks[0].size).toBe(50);
+  });
+
+  it("turns a NO ask into an executable bid", () => {
+    const bids = consolidatedBids({
+      lower: null,
+      upper: 4.04,
+      noAsks: [{ price: 95, size: 40 }],
+    });
+    expect(bids).toHaveLength(1);
+    expect(bids[0].price).toBeCloseTo(5, 10);
+  });
+
+  it("sorts the consolidated sides best first", () => {
+    const depth: BucketDepth = {
+      lower: null,
+      upper: 4.04,
+      yesBids: [{ price: 30, size: 10 }],
+      yesAsks: [{ price: 40, size: 10 }],
+      noBids: [{ price: 65, size: 10 }], // -> ask at 35, better than the YES ask
+      noAsks: [{ price: 68, size: 10 }], // -> bid at 32, better than the YES bid
+    };
+    expect(consolidatedBids(depth)[0].price).toBeCloseTo(32, 10);
+    expect(consolidatedAsks(depth)[0].price).toBeCloseTo(35, 10);
+  });
+});
+
+describe("the walk mid", () => {
+  it("gives the mid on symmetric depth", () => {
+    const est = bucketEstimateFromDepth({
+      lower: null,
+      upper: 4.04,
+      ...ladder(40),
+    });
+    expect(est.probability).toBeCloseTo(0.4, 6);
+    expect(est.quoted).toBe(true);
+    expect(est.oneSided).toBe(false);
+    expect(est.notionalUsd).toBeGreaterThan(0);
+  });
+
+  it("does not move the price when the ladder is imbalanced", () => {
+    // Size imbalance is denomination and inventory, not opinion (issue #36): on
+    // this venue all resting flow is the MM's own, so extra size behind the walk
+    // must leave the estimate exactly where it was.
+    const { yesBids, yesAsks } = ladder(40);
+    const heavy = yesBids.map((l) => ({ price: l.price, size: l.size * 10 }));
+    const pHeavy = bucketEstimateFromDepth({
+      lower: null,
+      upper: 4.04,
+      yesBids: heavy,
+      yesAsks,
+    }).probability;
+    const pFlat = bucketEstimateFromDepth({
+      lower: null,
+      upper: 4.04,
+      yesBids,
+      yesAsks,
+    }).probability;
+    expect(pHeavy).toBeCloseTo(pFlat!, 12);
+  });
+
+  it("stays between the best bid and the best ask", () => {
+    // The book only pins the truth to [best bid, best ask]; a published
+    // probability outside the executable bracket is dutch-bookable. The old
+    // microprice gave 18.4 on this real NVDA bucket against a best ask of 17.
+    const depth: BucketDepth = {
+      lower: null,
+      upper: 1.91,
+      yesBids: [
+        { price: 4, size: 386 },
+        { price: 3, size: 519 },
+        { price: 1, size: 1558 },
+      ],
+      noBids: [
+        { price: 83, size: 6 },
+        { price: 81, size: 25 },
+      ],
+      noAsks: [
+        { price: 97, size: 3 },
+        { price: 99, size: 20 },
+      ],
+    };
+    const p = bucketEstimateFromDepth(depth).probability!;
+    expect(p).toBeGreaterThanOrEqual(consolidatedBids(depth)[0].price / 100);
+    expect(p).toBeLessThanOrEqual(consolidatedAsks(depth)[0].price / 100);
+  });
+
+  it("prices a fragmented side instead of dropping it", () => {
+    // $5.77 of real asks split across two sub-$5 levels must still price the
+    // side (the floor is on the side total, never per level), so splitting an
+    // order into small clips cannot silence a side.
+    const est = bucketEstimateFromDepth({
+      lower: null,
+      upper: 1.91,
+      yesBids: [{ price: 4, size: 386 }],
+      // asks at 17 ($1.02) and 19 ($4.75)
+      noBids: [
+        { price: 83, size: 6 },
+        { price: 81, size: 25 },
+      ],
+    });
+    expect(est.quoted).toBe(true);
+    expect(est.oneSided).toBe(false);
+    // sell $5 at 4c; buy $5 = $1.02 at 17 then $3.98 at 19 -> 18.59; mid 11.3
+    expect(Math.abs(est.probability! - 0.113)).toBeLessThan(0.001);
+  });
+
+  it("gives no weight to size behind the walk", () => {
+    // 100k shares added at 1c behind the first $5 of bids must not move the
+    // estimate by a single bit.
+    const { yesBids, yesAsks, noBids, noAsks } = ladder(40);
+    const base = bucketEstimateFromDepth({
+      lower: null,
+      upper: 4.04,
+      yesBids,
+      yesAsks,
+      noBids,
+      noAsks,
+    }).probability;
+    const spammed = [...yesBids, { price: 1, size: 100_000 }];
+    const p = bucketEstimateFromDepth({
+      lower: null,
+      upper: 4.04,
+      yesBids: spammed,
+      yesAsks,
+      noBids,
+      noAsks,
+    }).probability;
+    expect(p).toBe(base);
+  });
+
+  it("walks a thin touch into the real depth", () => {
+    // A $1.68 best ask cannot speak for the side alone: the $5 walk carries into
+    // the next level, blending 42 and 45 by their committed dollars.
+    const p = bucketEstimateFromDepth({
+      lower: 2.06,
+      upper: 2.21,
+      yesBids: [
+        { price: 30, size: 7 },
+        { price: 29, size: 54 },
+        { price: 27, size: 58 },
+      ],
+      yesAsks: [
+        { price: 42, size: 4 },
+        { price: 45, size: 44 },
+      ],
+    }).probability!;
+    // sell $5: $2.10 at 30 + $2.90 at 29 = 29.42; buy $5: $1.68 at 42 +
+    // $3.32 at 45 = 43.99; mid 36.7
+    expect(Math.abs(p - 0.367)).toBeLessThan(0.001);
+  });
+
+  it("standardises confidence within the market", () => {
+    // Confidence compares each bucket to its OWN market's median depth, so a
+    // bucket at typical depth earns the full spread quality and a bucket at a
+    // fraction of typical depth is discounted proportionally. No external dollar
+    // constant is involved, and one whale bucket cannot crush the rest because
+    // the standard is the median.
+    const threeBounds: [number | null, number | null][] = [
+      [null, 1.0],
+      [1.0, 2.0],
+      [2.0, null],
+    ];
+    const f = forecastFromDepth(
+      build([62.5, 31.25, 6.25], [500, 500, 20], threeBounds)
+    )!;
+    const confs = f.buckets.map((b) => b.confidence);
+    expect(confs[0]).toBeCloseTo(confs[1], 10);
+    expect(confs[2]).toBeLessThan(confs[1] * 0.2);
+
+    const whale = forecastFromDepth(
+      build([62.5, 31.25, 6.25], [500, 50000, 500], threeBounds)
+    )!;
+    // A whale in one bucket must not crush its siblings' confidence.
+    expect(whale.buckets[0].confidence).toBeCloseTo(confs[0], 2);
+  });
+});
+
+// --- the issue #36 book, frozen ---------------------------------------------
+
+// Live NVDA EPS book, 2026-08-03. Under the old share-weighted microprice the
+// five raw estimates summed to 1.359 and two buckets priced above their own best
+// ask. The walk mid must keep every bucket inside its touch and the raw sum near
+// 1 (spread-wide, not ladder-wide).
+
+const NVDA_FROZEN: BucketDepth[] = [
+  {
+    lower: null,
+    upper: 1.91,
+    yesBids: [
+      { price: 4, size: 386 },
+      { price: 3, size: 519 },
+      { price: 1, size: 1558 },
+    ],
+    noBids: [
+      { price: 83, size: 6 },
+      { price: 81, size: 25 },
+    ],
+    noAsks: [
+      { price: 97, size: 3 },
+      { price: 99, size: 20 },
+    ],
+  },
+  {
+    lower: 1.91,
+    upper: 2.06,
+    yesBids: [
+      { price: 17, size: 96 },
+      { price: 16, size: 18 },
+      { price: 14, size: 122 },
+    ],
+    noBids: [
+      { price: 70, size: 19 },
+      { price: 68, size: 29 },
+    ],
+    noAsks: [{ price: 84, size: 5 }],
+  },
+  {
+    lower: 2.06,
+    upper: 2.21,
+    yesBids: [
+      { price: 30, size: 7 },
+      { price: 29, size: 54 },
+      { price: 27, size: 58 },
+    ],
+    yesAsks: [
+      { price: 42, size: 4 },
+      { price: 45, size: 44 },
+    ],
+    noBids: [
+      { price: 57, size: 7 },
+      { price: 55, size: 28 },
+    ],
+    noAsks: [{ price: 70, size: 16 }],
+  },
+  {
+    lower: 2.21,
+    upper: 2.35,
+    yesBids: [
+      { price: 15, size: 62 },
+      { price: 14, size: 111 },
+      { price: 12, size: 130 },
+    ],
+    yesAsks: [{ price: 27, size: 35 }],
+    noBids: [
+      { price: 72, size: 16 },
+      { price: 70, size: 29 },
+    ],
+    noAsks: [{ price: 99, size: 6 }],
+  },
+  {
+    lower: 2.35,
+    upper: null,
+    yesBids: [
+      { price: 4, size: 499 },
+      { price: 3, size: 667 },
+      { price: 1, size: 2000 },
+    ],
+    noBids: [
+      { price: 75, size: 37 },
+      { price: 74, size: 24 },
+      { price: 73, size: 51 },
+    ],
+    noAsks: [
+      { price: 97, size: 3 },
+      { price: 99, size: 20 },
+    ],
+  },
+];
+
+describe("the frozen NVDA book", () => {
+  it("keeps every bucket inside its touch", () => {
+    for (const depth of NVDA_FROZEN) {
+      const p = bucketEstimateFromDepth(depth).probability!;
+      expect(p).toBeGreaterThanOrEqual(consolidatedBids(depth)[0].price / 100);
+      expect(p).toBeLessThanOrEqual(consolidatedAsks(depth)[0].price / 100);
+    }
+  });
+
+  it("keeps the raw sum spread-wide rather than inflated", () => {
+    const total = NVDA_FROZEN.reduce(
+      (acc, d) => acc + bucketEstimateFromDepth(d).probability!,
+      0
+    );
+    const lo =
+      NVDA_FROZEN.reduce((acc, d) => acc + consolidatedBids(d)[0].price, 0) / 100;
+    const hi =
+      NVDA_FROZEN.reduce((acc, d) => acc + consolidatedAsks(d)[0].price, 0) / 100;
+    expect(total).toBeGreaterThanOrEqual(lo);
+    expect(total).toBeLessThanOrEqual(hi);
+    // was 1.359 under the microprice
+    expect(total).toBeLessThan(1.1);
+  });
+});
+
+describe("griefing", () => {
+  const GRIEF_BOUNDS: [number | null, number | null][] = [
+    [null, -2.0],
+    [-2.0, -1.0],
+    [-1.0, 1.0],
+    [1.0, 2.0],
+    [2.0, null],
+  ];
+
+  it("gives a dust ladder no weight", () => {
+    // A 1-share 90c bid on a dead tail moved the old estimator by 8 units.
+    // Summed over the full book it is $0.90, under the side floor, so absent.
+    const base = build([45, 5, 1, 5, 45], undefined, GRIEF_BOUNDS);
+    const f0 = forecastFromDepth(base)!;
+    const griefed = [...base];
+    griefed[4] = {
+      lower: 2.0,
+      upper: null,
+      yesBids: [{ price: 90, size: 1 }],
+    };
+    const f1 = forecastFromDepth(griefed)!;
+    // the dusted bucket contributes exactly what an unquoted one would
+    const unquoted = forecastFromDepth([
+      ...base.slice(0, 4),
+      { lower: 2.0, upper: null },
+    ])!;
+    expect(f1.value).toBeCloseTo(unquoted.value, 10);
+    expect(Math.abs(f1.value - f0.value)).toBeLessThan(8.0);
+  });
+
+  it("does count real size at the same price", () => {
+    const base = build([45, 5, 1, 5, 45], undefined, GRIEF_BOUNDS);
+    const sized = [...base];
+    sized[4] = {
+      lower: 2.0,
+      upper: null,
+      yesBids: [{ price: 90, size: 50 }], // $45 resting
+    };
+    const f0 = forecastFromDepth(base)!;
+    const f1 = forecastFromDepth(sized)!;
+    expect(f1.value).not.toBeCloseTo(f0.value, 6);
+  });
+});
+
+describe("forecastFromDepth: degenerate input", () => {
+  it("returns null when every book is empty", () => {
+    expect(
+      forecastFromDepth(BOUNDS.map(([lower, upper]) => ({ lower, upper })))
+    ).toBeNull();
+  });
+
+  it("survives a one-sided bucket", () => {
+    const threeBounds: [number | null, number | null][] = [
+      [null, 1.0],
+      [1.0, 2.0],
+      [2.0, null],
+    ];
+    const buckets = build([62.5, 31.25, null], undefined, threeBounds);
+    // ask-only after inversion
+    buckets[2] = {
+      lower: 2.0,
+      upper: null,
+      noBids: [{ price: 93, size: 100 }],
+    };
+    const f = forecastFromDepth(buckets);
+    expect(f).not.toBeNull();
+    expect(Number.isFinite(f!.value)).toBe(true);
+  });
+
+  it("quarantines a crossed consolidated touch", () => {
+    // YES bid 61.5 vs NO bid 45 -> consolidated ask 55 < bid 61.5: the
+    // arbitrage state. Must be quarantined, not averaged.
+    const threeBounds: [number | null, number | null][] = [
+      [null, 1.0],
+      [1.0, 2.0],
+      [2.0, null],
+    ];
+    const buckets = build([62.5, 31.25, 6.25], undefined, threeBounds);
+    const crossed: BucketDepth = {
+      lower: null,
+      upper: 1.0,
+      yesBids: [{ price: 61.5, size: 100 }],
+      noBids: [{ price: 45, size: 100 }], // -> consolidated ask at 55, crossed
+    };
+    const f = forecastFromDepth([crossed, ...buckets.slice(1)])!;
+    expect(f.warnings.some((w) => w.includes("crossed"))).toBe(true);
+  });
+
+  it("matches the quote path on symmetric books", () => {
+    // On a symmetric mirrored book the depth path and the best-quote path must
+    // agree on the probabilities (same mids, same residuals).
+    const btcBounds: [number | null, number | null][] = [
+      [null, 65000.0],
+      [65000.0, 70000.0],
+      [70000.0, null],
+    ];
+    const mids = [62.5, 31.25, 6.25];
+    const depth = build(mids, undefined, btcBounds);
+    const quotes: BucketBook[] = btcBounds.map(([lower, upper], i) => ({
+      lower,
+      upper,
+      bestBid: mids[i] - 1,
+      bestAsk: mids[i] + 1,
+    }));
+    const fd = forecastFromDepth(depth)!;
+    const fq = forecastFromBuckets(quotes)!;
+    fd.buckets.forEach((b, i) => {
+      expect(b.probability).toBeCloseTo(fq.buckets[i].probability, 9);
+    });
+    expect(fd.value).toBeCloseTo(fq.value, 6);
+  });
+});

--- a/src/util/forecastDepth.test.ts
+++ b/src/util/forecastDepth.test.ts
@@ -32,7 +32,16 @@ const BOUNDS: [number | null, number | null][] = [
 
 const round4 = (x: number) => Math.round(x * 1e4) / 1e4;
 
-/** Symmetric YES ladders plus the exact NO mirror our MM would post. */
+/**
+ * Symmetric YES ladders plus the exact NO mirror our MM would post.
+ *
+ * The mirror is deliberate and load-bearing: after consolidation every price
+ * appears TWICE (once from the YES side, once from the inverted NO side), so a
+ * bucket's side notional is double what the YES ladder alone would hold. Walk
+ * prices are unaffected — the duplicate sits at the same price — but the
+ * doubling is what lets the thin bucket in the confidence test clear
+ * DEPTH_MIN_SIDE_NOTIONAL_USD while still being a fraction of its siblings.
+ */
 function ladder(mid: number, size = 100, levels = 3, spread = 2, step = 1) {
   const yesBids: BookLevel[] = [];
   const yesAsks: BookLevel[] = [];
@@ -229,11 +238,17 @@ describe("the walk mid", () => {
       [1.0, 2.0],
       [2.0, null],
     ];
+    // Size 40 puts the thin bucket's consolidated sides at ~$10, comfortably
+    // clear of the $5 side floor. At 20 it landed on $5.10: still quoted, but
+    // close enough that a small change elsewhere would drop the side entirely
+    // and leave this test passing for the wrong reason (an unquoted bucket has
+    // confidence 0, which trivially satisfies the ratio check below).
     const f = forecastFromDepth(
-      build([62.5, 31.25, 6.25], [500, 500, 20], threeBounds)
+      build([62.5, 31.25, 6.25], [500, 500, 40], threeBounds)
     )!;
     const confs = f.buckets.map((b) => b.confidence);
     expect(confs[0]).toBeCloseTo(confs[1], 10);
+    expect(confs[2]).toBeGreaterThan(0);
     expect(confs[2]).toBeLessThan(confs[1] * 0.2);
 
     const whale = forecastFromDepth(

--- a/src/util/marketBuckets.test.ts
+++ b/src/util/marketBuckets.test.ts
@@ -76,34 +76,43 @@ const TIMESTAMP = 1700000000;
 /** Big enough that even a 1c level clears DEPTH_MIN_SIDE_NOTIONAL_USD. */
 const SIZE = 1000;
 
-function belowComponents(threshold: string, streamId = STREAM_ID): Uint8Array {
+function belowComponents(
+  threshold: string,
+  streamId = STREAM_ID,
+  timestamp = TIMESTAMP
+): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
     streamId,
     "price_below_threshold",
-    encodeActionArgs(DATA_PROVIDER, streamId, TIMESTAMP, threshold, 0)
+    encodeActionArgs(DATA_PROVIDER, streamId, timestamp, threshold, 0)
   );
 }
 
-function aboveComponents(threshold: string, streamId = STREAM_ID): Uint8Array {
+function aboveComponents(
+  threshold: string,
+  streamId = STREAM_ID,
+  timestamp = TIMESTAMP
+): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
     streamId,
     "price_above_threshold",
-    encodeActionArgs(DATA_PROVIDER, streamId, TIMESTAMP, threshold, 0)
+    encodeActionArgs(DATA_PROVIDER, streamId, timestamp, threshold, 0)
   );
 }
 
 function betweenComponents(
   min: string,
   max: string,
-  streamId = STREAM_ID
+  streamId = STREAM_ID,
+  timestamp = TIMESTAMP
 ): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
     streamId,
     "value_in_range",
-    encodeRangeActionArgs(DATA_PROVIDER, streamId, TIMESTAMP, min, max, 0)
+    encodeRangeActionArgs(DATA_PROVIDER, streamId, timestamp, min, max, 0)
   );
 }
 
@@ -174,6 +183,33 @@ const OTHER_MARKETS: Record<number, FakeMarket> = {
   },
   203: {
     components: aboveComponents("4.33", OTHER_STREAM_ID),
+    bounds: { lower: 4.33, upper: null },
+    yesBid: 44,
+    yesAsk: 56,
+  },
+};
+
+/**
+ * A third set that settle_time alone cannot tell apart: same provider, same
+ * stream, same settlement, but observing the stream a day later. Only the
+ * query timestamp separates it from MSFT_MARKETS.
+ */
+const LATER_TIMESTAMP = TIMESTAMP + 86400;
+const LATER_MARKETS: Record<number, FakeMarket> = {
+  301: {
+    components: belowComponents("4.04", STREAM_ID, LATER_TIMESTAMP),
+    bounds: { lower: null, upper: 4.04 },
+    yesBid: 1,
+    yesAsk: null,
+  },
+  302: {
+    components: betweenComponents("4.04", "4.33", STREAM_ID, LATER_TIMESTAMP),
+    bounds: { lower: 4.04, upper: 4.33 },
+    yesBid: 16,
+    yesAsk: 28,
+  },
+  303: {
+    components: aboveComponents("4.33", STREAM_ID, LATER_TIMESTAMP),
     bounds: { lower: 4.33, upper: null },
     yesBid: 44,
     yesAsk: 56,
@@ -333,6 +369,18 @@ describe("getMarketForecast", () => {
     // the other's total and return a confident number about nothing. Both sets
     // are individually valid, so nothing but the identity check catches this.
     const both = { ...MSFT_MARKETS, ...OTHER_MARKETS };
+    await expect(
+      fakeAction({ markets: both }).getMarketForecast(
+        Object.keys(both).map(Number)
+      )
+    ).rejects.toThrow(/different event/);
+  });
+
+  it("rejects two markets that differ only in the time they observe", async () => {
+    // The case settleTime alone cannot see: same provider, same stream, same
+    // settlement, but a different point in the stream. Without timestamp in the
+    // identity these two would merge silently.
+    const both = { ...MSFT_MARKETS, ...LATER_MARKETS };
     await expect(
       fakeAction({ markets: both }).getMarketForecast(
         Object.keys(both).map(Number)

--- a/src/util/marketBuckets.test.ts
+++ b/src/util/marketBuckets.test.ts
@@ -76,29 +76,34 @@ const TIMESTAMP = 1700000000;
 /** Big enough that even a 1c level clears DEPTH_MIN_SIDE_NOTIONAL_USD. */
 const SIZE = 1000;
 
+/** frozenAt 0 encodes as NULL, which is how "latest" is expressed on chain. */
+const LATEST = 0;
+
 function belowComponents(
   threshold: string,
   streamId = STREAM_ID,
-  timestamp = TIMESTAMP
+  timestamp = TIMESTAMP,
+  frozenAt = LATEST
 ): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
     streamId,
     "price_below_threshold",
-    encodeActionArgs(DATA_PROVIDER, streamId, timestamp, threshold, 0)
+    encodeActionArgs(DATA_PROVIDER, streamId, timestamp, threshold, frozenAt)
   );
 }
 
 function aboveComponents(
   threshold: string,
   streamId = STREAM_ID,
-  timestamp = TIMESTAMP
+  timestamp = TIMESTAMP,
+  frozenAt = LATEST
 ): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
     streamId,
     "price_above_threshold",
-    encodeActionArgs(DATA_PROVIDER, streamId, timestamp, threshold, 0)
+    encodeActionArgs(DATA_PROVIDER, streamId, timestamp, threshold, frozenAt)
   );
 }
 
@@ -106,13 +111,21 @@ function betweenComponents(
   min: string,
   max: string,
   streamId = STREAM_ID,
-  timestamp = TIMESTAMP
+  timestamp = TIMESTAMP,
+  frozenAt = LATEST
 ): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
     streamId,
     "value_in_range",
-    encodeRangeActionArgs(DATA_PROVIDER, streamId, timestamp, min, max, 0)
+    encodeRangeActionArgs(
+      DATA_PROVIDER,
+      streamId,
+      timestamp,
+      min,
+      max,
+      frozenAt
+    )
   );
 }
 
@@ -210,6 +223,39 @@ const LATER_MARKETS: Record<number, FakeMarket> = {
   },
   303: {
     components: aboveComponents("4.33", STREAM_ID, LATER_TIMESTAMP),
+    bounds: { lower: 4.33, upper: null },
+    yesBid: 44,
+    yesAsk: 56,
+  },
+};
+
+/**
+ * A fourth set identical to MSFT_MARKETS in every field but `frozenAt`: the
+ * same question asked of data pinned to a block rather than of latest data.
+ * That is a different query, and only frozenAt says so.
+ */
+const PINNED_BLOCK = 987654;
+const PINNED_MARKETS: Record<number, FakeMarket> = {
+  401: {
+    components: belowComponents("4.04", STREAM_ID, TIMESTAMP, PINNED_BLOCK),
+    bounds: { lower: null, upper: 4.04 },
+    yesBid: 1,
+    yesAsk: null,
+  },
+  402: {
+    components: betweenComponents(
+      "4.04",
+      "4.33",
+      STREAM_ID,
+      TIMESTAMP,
+      PINNED_BLOCK
+    ),
+    bounds: { lower: 4.04, upper: 4.33 },
+    yesBid: 16,
+    yesAsk: 28,
+  },
+  403: {
+    components: aboveComponents("4.33", STREAM_ID, TIMESTAMP, PINNED_BLOCK),
     bounds: { lower: 4.33, upper: null },
     yesBid: 44,
     yesAsk: 56,
@@ -381,6 +427,18 @@ describe("getMarketForecast", () => {
     // settlement, but a different point in the stream. Without timestamp in the
     // identity these two would merge silently.
     const both = { ...MSFT_MARKETS, ...LATER_MARKETS };
+    await expect(
+      fakeAction({ markets: both }).getMarketForecast(
+        Object.keys(both).map(Number)
+      )
+    ).rejects.toThrow(/different event/);
+  });
+
+  it("rejects two markets that differ only in the block they freeze", async () => {
+    // frozenAt is the other query field settleTime cannot see: the same
+    // question asked of pinned data and of latest data is two different
+    // queries.
+    const both = { ...MSFT_MARKETS, ...PINNED_MARKETS };
     await expect(
       fakeAction({ markets: both }).getMarketForecast(
         Object.keys(both).map(Number)

--- a/src/util/marketBuckets.test.ts
+++ b/src/util/marketBuckets.test.ts
@@ -17,10 +17,13 @@ import type { MarketInfo, OrderBookEntry } from "../types/orderbook";
 import { BookLevel, BucketDepth, forecastFromDepth } from "./forecast";
 import { bucketBoundsFromMarketData, requireQueryTime } from "./marketBuckets";
 import {
+  decodeMarketData,
   encodeActionArgs,
   encodeQueryComponents,
   encodeRangeActionArgs,
 } from "./orderbookHelpers";
+import { encodeActionArgs as encodeKwilArgs } from "./AttestationEncoding";
+import { Utils } from "@trufnetwork/kwil-js";
 
 describe("bucketBoundsFromMarketData", () => {
   it("reads a below market as the open bottom bucket", () => {
@@ -98,6 +101,65 @@ describe("bucketBoundsFromMarketData", () => {
         })
       ).toThrow(/positive tolerance/);
     }
+  });
+
+  it("rejects equals bounds that collapse or overflow", () => {
+    // A positive tolerance is not enough. Absorbed by a large target it leaves
+    // both edges on the same value, and near the float limits the sum
+    // overflows; either way the bucket cannot hold an outcome.
+    expect(1e300 - 1e-300).toBe(1e300 + 1e-300); // the collapse, demonstrated
+    expect(() =>
+      bucketBoundsFromMarketData({
+        type: "equals",
+        thresholds: ["1e300", "1e-300"],
+      })
+    ).toThrow(/usable bucket/);
+
+    expect(() =>
+      bucketBoundsFromMarketData({
+        type: "equals",
+        thresholds: ["1.7e308", "1.7e308"],
+      })
+    ).toThrow(/usable bucket/);
+  });
+});
+
+describe("decodeMarketData query time", () => {
+  const DP = "0x4710a8d8f0d845da110086812a32de6d90d7ff5c";
+  const SID = "stmsft00000000000000000000000000";
+
+  it("keeps an explicit ABI NULL frozenAt as null", () => {
+    // Every well-formed market on chain carries NULL there, meaning "latest".
+    const market = decodeMarketData(
+      encodeQueryComponents(
+        DP,
+        SID,
+        "price_below_threshold",
+        encodeActionArgs(DP, SID, 1700000000, "4.04", 0)
+      )
+    );
+    expect(market.timestamp).toBe(1700000000);
+    expect(market.frozenAt).toBeNull();
+  });
+
+  it("leaves the timestamp unread when the argument list is truncated", () => {
+    // A missing final INT8 would otherwise decode to null, which is
+    // indistinguishable from the explicit NULL above — so a malformed market
+    // would match a healthy one on that component of its identity. Dropping the
+    // timestamp instead routes it to requireQueryTime, which refuses it.
+    const truncated = encodeKwilArgs([DP, SID, 1700000000, "4.04"], {
+      3: Utils.DataType.Numeric(36, 18),
+    });
+    const market = decodeMarketData(
+      encodeQueryComponents(DP, SID, "price_below_threshold", truncated)
+    );
+
+    expect(market.type).toBe("below");
+    expect(market.thresholds).toHaveLength(1);
+    expect(market.timestamp).toBeNull();
+    expect(() => requireQueryTime(101, market)).toThrow(
+      /no readable query timestamp/
+    );
   });
 });
 

--- a/src/util/marketBuckets.test.ts
+++ b/src/util/marketBuckets.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect } from "vitest";
 import { OrderbookAction } from "../contracts-api/orderbookAction";
 import type { MarketInfo, OrderBookEntry } from "../types/orderbook";
 import { BookLevel, BucketDepth, forecastFromDepth } from "./forecast";
-import { bucketBoundsFromMarketData } from "./marketBuckets";
+import { bucketBoundsFromMarketData, requireQueryTime } from "./marketBuckets";
 import {
   encodeActionArgs,
   encodeQueryComponents,
@@ -64,6 +64,64 @@ describe("bucketBoundsFromMarketData", () => {
     expect(() =>
       bucketBoundsFromMarketData({ type: "between", thresholds: ["4.33"] })
     ).toThrow(/threshold/);
+  });
+
+  it("rejects a non-finite threshold", () => {
+    // Number("Infinity") is a value, not an error; left alone it surfaces as a
+    // NaN forecast rather than as this market being unreadable.
+    for (const threshold of ["NaN", "Infinity", "-Infinity", "abc"]) {
+      expect(() =>
+        bucketBoundsFromMarketData({ type: "below", thresholds: [threshold] })
+      ).toThrow(/not a number/);
+    }
+  });
+
+  it("rejects an inverted or empty between bucket", () => {
+    // Bounds are half-open [lower, upper): equal bounds are empty and inverted
+    // ones can never hold an outcome.
+    for (const thresholds of [
+      ["4.62", "4.33"],
+      ["4.33", "4.33"],
+    ]) {
+      expect(() =>
+        bucketBoundsFromMarketData({ type: "between", thresholds })
+      ).toThrow(/lower < upper/);
+    }
+  });
+
+  it("rejects a non-positive equals tolerance", () => {
+    for (const tolerance of ["0", "-0.10"]) {
+      expect(() =>
+        bucketBoundsFromMarketData({
+          type: "equals",
+          thresholds: ["5.25", tolerance],
+        })
+      ).toThrow(/positive tolerance/);
+    }
+  });
+});
+
+describe("requireQueryTime", () => {
+  it("rejects a market whose query timestamp could not be read", () => {
+    // The identity stringifies null as "null", so two malformed markets would
+    // collide there and match each other. Refusing them is the point.
+    expect(() => requireQueryTime(101, { type: "below", timestamp: null })).toThrow(
+      /no readable query timestamp/
+    );
+  });
+
+  it("accepts a readable timestamp", () => {
+    expect(() =>
+      requireQueryTime(101, { type: "below", timestamp: 1700000000 })
+    ).not.toThrow();
+  });
+
+  it("leaves an unknown action type alone", () => {
+    // Its layout is unknown, so argument 2 need not be a timestamp at all; the
+    // bounds derivation rejects it with a better message.
+    expect(() =>
+      requireQueryTime(101, { type: "unknown", timestamp: null })
+    ).not.toThrow();
   });
 });
 
@@ -131,6 +189,8 @@ function betweenComponents(
 
 interface FakeMarket {
   components: Uint8Array;
+  /** Collateral namespace; part of the market's identity. */
+  bridge?: string;
   bounds: { lower: number | null; upper: number | null };
   yesBid: number | null;
   yesAsk: number | null;
@@ -294,6 +354,7 @@ function fakeAction(options?: {
         ? markets[queryId].components
         : new Uint8Array(0),
       settleTime: TIMESTAMP,
+      bridge: markets[queryId].bridge ?? "eth_usdc",
     }) as MarketInfo;
 
   action.getOrderBook = async (queryId: number, outcome: boolean) => {
@@ -439,6 +500,22 @@ describe("getMarketForecast", () => {
     // question asked of pinned data and of latest data is two different
     // queries.
     const both = { ...MSFT_MARKETS, ...PINNED_MARKETS };
+    await expect(
+      fakeAction({ markets: both }).getMarketForecast(
+        Object.keys(both).map(Number)
+      )
+    ).rejects.toThrow(/different event/);
+  });
+
+  it("rejects two markets that differ only in their bridge", async () => {
+    // The bridge is the one identity field outside the query components: it is
+    // a createMarket argument, so an identical question can be collateralised
+    // two ways. Those are separate markets with separate books.
+    const bridged: Record<number, FakeMarket> = {};
+    for (const [id, market] of Object.entries(MSFT_MARKETS)) {
+      bridged[Number(id) + 500] = { ...market, bridge: "eth_truf" };
+    }
+    const both = { ...MSFT_MARKETS, ...bridged };
     await expect(
       fakeAction({ markets: both }).getMarketForecast(
         Object.keys(both).map(Number)

--- a/src/util/marketBuckets.test.ts
+++ b/src/util/marketBuckets.test.ts
@@ -76,30 +76,34 @@ const TIMESTAMP = 1700000000;
 /** Big enough that even a 1c level clears DEPTH_MIN_SIDE_NOTIONAL_USD. */
 const SIZE = 1000;
 
-function belowComponents(threshold: string): Uint8Array {
+function belowComponents(threshold: string, streamId = STREAM_ID): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
-    STREAM_ID,
+    streamId,
     "price_below_threshold",
-    encodeActionArgs(DATA_PROVIDER, STREAM_ID, TIMESTAMP, threshold, 0)
+    encodeActionArgs(DATA_PROVIDER, streamId, TIMESTAMP, threshold, 0)
   );
 }
 
-function aboveComponents(threshold: string): Uint8Array {
+function aboveComponents(threshold: string, streamId = STREAM_ID): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
-    STREAM_ID,
+    streamId,
     "price_above_threshold",
-    encodeActionArgs(DATA_PROVIDER, STREAM_ID, TIMESTAMP, threshold, 0)
+    encodeActionArgs(DATA_PROVIDER, streamId, TIMESTAMP, threshold, 0)
   );
 }
 
-function betweenComponents(min: string, max: string): Uint8Array {
+function betweenComponents(
+  min: string,
+  max: string,
+  streamId = STREAM_ID
+): Uint8Array {
   return encodeQueryComponents(
     DATA_PROVIDER,
-    STREAM_ID,
+    streamId,
     "value_in_range",
-    encodeRangeActionArgs(DATA_PROVIDER, STREAM_ID, TIMESTAMP, min, max, 0)
+    encodeRangeActionArgs(DATA_PROVIDER, streamId, TIMESTAMP, min, max, 0)
   );
 }
 
@@ -150,6 +154,32 @@ const MSFT_MARKETS: Record<number, FakeMarket> = {
 
 const ALL_QUERY_IDS = Object.keys(MSFT_MARKETS).map(Number);
 
+/**
+ * A second, independently valid bucket set, on a different stream. Each set
+ * forecasts fine alone; the two together describe unrelated events.
+ */
+const OTHER_STREAM_ID = "stother0000000000000000000000000";
+const OTHER_MARKETS: Record<number, FakeMarket> = {
+  201: {
+    components: belowComponents("4.04", OTHER_STREAM_ID),
+    bounds: { lower: null, upper: 4.04 },
+    yesBid: 1,
+    yesAsk: null,
+  },
+  202: {
+    components: betweenComponents("4.04", "4.33", OTHER_STREAM_ID),
+    bounds: { lower: 4.04, upper: 4.33 },
+    yesBid: 16,
+    yesAsk: 28,
+  },
+  203: {
+    components: aboveComponents("4.33", OTHER_STREAM_ID),
+    bounds: { lower: 4.33, upper: null },
+    yesBid: 44,
+    yesAsk: 56,
+  },
+};
+
 function row(price: number): OrderBookEntry {
   return {
     walletAddress: new Uint8Array(20),
@@ -181,6 +211,7 @@ function fakeAction(options?: {
       queryComponents: withComponents
         ? markets[queryId].components
         : new Uint8Array(0),
+      settleTime: TIMESTAMP,
     }) as MarketInfo;
 
   action.getOrderBook = async (queryId: number, outcome: boolean) => {
@@ -198,7 +229,9 @@ function fakeAction(options?: {
 
 /** The same books, built directly, to compare the assembled path against. */
 function depths(): BucketDepth[] {
-  return ALL_QUERY_IDS.sort((a, b) => a - b).map((queryId) => {
+  // Copy before sorting: ALL_QUERY_IDS is shared, and other tests assert on its
+  // order.
+  return [...ALL_QUERY_IDS].sort((a, b) => a - b).map((queryId) => {
     const { bounds, yesBid, yesAsk } = MSFT_MARKETS[queryId];
     const yesBids: BookLevel[] =
       yesBid !== null ? [{ price: yesBid, size: SIZE }] : [];
@@ -285,6 +318,36 @@ describe("getMarketForecast", () => {
     await expect(fakeAction().getMarketForecast([103])).rejects.toThrow(
       /at least 2/
     );
+  });
+
+  it("rejects duplicate query ids", async () => {
+    // A repeated bucket would have its probability counted twice, quietly
+    // reshaping the distribution rather than failing.
+    await expect(
+      fakeAction().getMarketForecast([101, 102, 103, 103])
+    ).rejects.toThrow(/duplicate/);
+  });
+
+  it("rejects buckets belonging to two different markets", async () => {
+    // Normalising across two events would divide one market's probabilities by
+    // the other's total and return a confident number about nothing. Both sets
+    // are individually valid, so nothing but the identity check catches this.
+    const both = { ...MSFT_MARKETS, ...OTHER_MARKETS };
+    await expect(
+      fakeAction({ markets: both }).getMarketForecast(
+        Object.keys(both).map(Number)
+      )
+    ).rejects.toThrow(/different event/);
+  });
+
+  it("still forecasts each of those sets on its own", async () => {
+    // The identity check must reject the mixture without rejecting either half.
+    expect(await fakeAction().getMarketForecast(ALL_QUERY_IDS)).not.toBeNull();
+    expect(
+      await fakeAction({ markets: OTHER_MARKETS }).getMarketForecast(
+        Object.keys(OTHER_MARKETS).map(Number)
+      )
+    ).not.toBeNull();
   });
 
   it("rejects a market without query components", async () => {

--- a/src/util/marketBuckets.test.ts
+++ b/src/util/marketBuckets.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for the SDK-side glue around the forecast algorithm.
+ *
+ * The algorithm itself is covered by forecast.test.ts / forecastDepth.test.ts.
+ * What is tested here is only what the SDK adds: deriving bucket bounds from
+ * decoded market data, and assembling a market's order books into a forecast.
+ *
+ * Ported from sdk-py's tests/test_market_buckets.py, with one improvement: the
+ * bucket bounds are read out of REAL ABI-encoded query components rather than a
+ * stubbed decoder, so the encode -> decode -> bounds path is exercised end to
+ * end.
+ */
+
+import { describe, it, expect } from "vitest";
+import { OrderbookAction } from "../contracts-api/orderbookAction";
+import type { MarketInfo, OrderBookEntry } from "../types/orderbook";
+import { BookLevel, BucketDepth, forecastFromDepth } from "./forecast";
+import { bucketBoundsFromMarketData } from "./marketBuckets";
+import {
+  encodeActionArgs,
+  encodeQueryComponents,
+  encodeRangeActionArgs,
+} from "./orderbookHelpers";
+
+describe("bucketBoundsFromMarketData", () => {
+  it("reads a below market as the open bottom bucket", () => {
+    expect(
+      bucketBoundsFromMarketData({ type: "below", thresholds: ["4.04"] })
+    ).toEqual({ lower: null, upper: 4.04 });
+  });
+
+  it("reads an above market as the open top bucket", () => {
+    expect(
+      bucketBoundsFromMarketData({ type: "above", thresholds: ["4.92"] })
+    ).toEqual({ lower: 4.92, upper: null });
+  });
+
+  it("reads a between market as an interior bucket", () => {
+    expect(
+      bucketBoundsFromMarketData({ type: "between", thresholds: ["4.33", "4.62"] })
+    ).toEqual({ lower: 4.33, upper: 4.62 });
+  });
+
+  it("reads an equals market as target plus or minus tolerance", () => {
+    // Its thresholds are (target, tolerance), NOT (lower, upper). Reading them
+    // positionally the way `between` is read would yield the bucket
+    // (5.25, 0.10): inverted, and silently wrong rather than loud.
+    const { lower, upper } = bucketBoundsFromMarketData({
+      type: "equals",
+      thresholds: ["5.25", "0.10"],
+    });
+    expect(lower).toBeCloseTo(5.15, 10);
+    expect(upper).toBeCloseTo(5.35, 10);
+    expect(lower!).toBeLessThan(upper!);
+  });
+
+  it("rejects a market type that cannot describe a bucket", () => {
+    expect(() =>
+      bucketBoundsFromMarketData({ type: "unknown", thresholds: [] })
+    ).toThrow(/cannot derive bucket bounds/);
+  });
+
+  it("rejects missing thresholds", () => {
+    expect(() =>
+      bucketBoundsFromMarketData({ type: "between", thresholds: ["4.33"] })
+    ).toThrow(/threshold/);
+  });
+});
+
+// --- client assembly ---------------------------------------------------------
+
+const DATA_PROVIDER = "0x4710a8d8f0d845da110086812a32de6d90d7ff5c";
+const STREAM_ID = "stmsft00000000000000000000000000";
+const TIMESTAMP = 1700000000;
+
+/** Big enough that even a 1c level clears DEPTH_MIN_SIDE_NOTIONAL_USD. */
+const SIZE = 1000;
+
+function belowComponents(threshold: string): Uint8Array {
+  return encodeQueryComponents(
+    DATA_PROVIDER,
+    STREAM_ID,
+    "price_below_threshold",
+    encodeActionArgs(DATA_PROVIDER, STREAM_ID, TIMESTAMP, threshold, 0)
+  );
+}
+
+function aboveComponents(threshold: string): Uint8Array {
+  return encodeQueryComponents(
+    DATA_PROVIDER,
+    STREAM_ID,
+    "price_above_threshold",
+    encodeActionArgs(DATA_PROVIDER, STREAM_ID, TIMESTAMP, threshold, 0)
+  );
+}
+
+function betweenComponents(min: string, max: string): Uint8Array {
+  return encodeQueryComponents(
+    DATA_PROVIDER,
+    STREAM_ID,
+    "value_in_range",
+    encodeRangeActionArgs(DATA_PROVIDER, STREAM_ID, TIMESTAMP, min, max, 0)
+  );
+}
+
+interface FakeMarket {
+  components: Uint8Array;
+  bounds: { lower: number | null; upper: number | null };
+  yesBid: number | null;
+  yesAsk: number | null;
+}
+
+/**
+ * The live mainnet MSFT book, as five separate markets. Bounds are carried in
+ * each bucket's own query_components, exactly as on chain. Quotes are
+ * (yesBid, yesAsk) in cents; null means nothing resting on that side.
+ */
+const MSFT_MARKETS: Record<number, FakeMarket> = {
+  101: {
+    components: belowComponents("4.04"),
+    bounds: { lower: null, upper: 4.04 },
+    yesBid: 1,
+    yesAsk: null,
+  },
+  102: {
+    components: betweenComponents("4.04", "4.33"),
+    bounds: { lower: 4.04, upper: 4.33 },
+    yesBid: 16,
+    yesAsk: 28,
+  },
+  103: {
+    components: betweenComponents("4.33", "4.62"),
+    bounds: { lower: 4.33, upper: 4.62 },
+    yesBid: 44,
+    yesAsk: 56,
+  },
+  104: {
+    components: betweenComponents("4.62", "4.92"),
+    bounds: { lower: 4.62, upper: 4.92 },
+    yesBid: 9,
+    yesAsk: 21,
+  },
+  105: {
+    components: aboveComponents("4.92"),
+    bounds: { lower: 4.92, upper: null },
+    yesBid: 1,
+    yesAsk: null,
+  },
+};
+
+const ALL_QUERY_IDS = Object.keys(MSFT_MARKETS).map(Number);
+
+function row(price: number): OrderBookEntry {
+  return {
+    walletAddress: new Uint8Array(20),
+    price,
+    amount: SIZE,
+    lastUpdated: TIMESTAMP,
+  };
+}
+
+/**
+ * An OrderbookAction whose network calls are stubbed.
+ *
+ * Built with Object.create so no Kwil client is needed: this exercises the
+ * assembly logic (bounds, sorting, layout checks) with no node.
+ */
+function fakeAction(options?: {
+  markets?: Record<number, FakeMarket>;
+  queryComponents?: boolean;
+  noBooks?: Record<number, OrderBookEntry[]>;
+}): OrderbookAction {
+  const markets = options?.markets ?? MSFT_MARKETS;
+  const withComponents = options?.queryComponents ?? true;
+  const noBooks = options?.noBooks ?? {};
+
+  const action = Object.create(OrderbookAction.prototype) as OrderbookAction;
+
+  action.getMarketInfo = async (queryId: number) =>
+    ({
+      queryComponents: withComponents
+        ? markets[queryId].components
+        : new Uint8Array(0),
+    }) as MarketInfo;
+
+  action.getOrderBook = async (queryId: number, outcome: boolean) => {
+    if (!outcome) return noBooks[queryId] ?? [];
+    const { yesBid, yesAsk } = markets[queryId];
+    const rows: OrderBookEntry[] = [];
+    // Bids carry a NEGATIVE price on the wire, asks a positive one.
+    if (yesBid !== null) rows.push(row(-yesBid));
+    if (yesAsk !== null) rows.push(row(yesAsk));
+    return rows;
+  };
+
+  return action;
+}
+
+/** The same books, built directly, to compare the assembled path against. */
+function depths(): BucketDepth[] {
+  return ALL_QUERY_IDS.sort((a, b) => a - b).map((queryId) => {
+    const { bounds, yesBid, yesAsk } = MSFT_MARKETS[queryId];
+    const yesBids: BookLevel[] =
+      yesBid !== null ? [{ price: yesBid, size: SIZE }] : [];
+    const yesAsks: BookLevel[] =
+      yesAsk !== null ? [{ price: yesAsk, size: SIZE }] : [];
+    return { ...bounds, yesBids, yesAsks, queryId };
+  });
+}
+
+describe("getMarketForecast", () => {
+  it("matches a direct call to the algorithm", async () => {
+    // Assembly must not change the answer: same books in, same number out.
+    const assembled = (await fakeAction().getMarketForecast(ALL_QUERY_IDS))!;
+    const direct = forecastFromDepth(depths())!;
+
+    expect(assembled.value).toBeCloseTo(direct.value, 10);
+    expect(assembled.p10).toBeCloseTo(direct.p10!, 10);
+    expect(assembled.p90).toBeCloseTo(direct.p90!, 10);
+    assembled.buckets.forEach((b, i) => {
+      expect(b.probability).toBeCloseTo(direct.buckets[i].probability, 10);
+    });
+  });
+
+  it("lands inside the leading bucket", async () => {
+    // The live MSFT book: the tight 44-56 bucket leads, so the value belongs
+    // inside it.
+    const f = (await fakeAction().getMarketForecast(ALL_QUERY_IDS))!;
+    const probs = f.buckets.map((b) => b.probability);
+    expect(probs[2]).toBe(Math.max(...probs));
+    expect(f.value).toBeGreaterThanOrEqual(4.33);
+    expect(f.value).toBeLessThanOrEqual(4.62);
+  });
+
+  it("consolidates NO-side liquidity into the estimate", async () => {
+    // A resting BUY NO at p is hittable by a BUY YES at 100-p, so NO depth is
+    // executable YES depth. Adding a NO bid must therefore supply the missing
+    // YES ask and stop the bucket reading as one-sided.
+    const bare = (await fakeAction().getMarketForecast(ALL_QUERY_IDS))!;
+    // A NO bid at 84 mirrors to a YES ask at 16 on the open bottom bucket.
+    const withNo = (await fakeAction({
+      noBooks: { 101: [row(-84)] },
+    }).getMarketForecast(ALL_QUERY_IDS))!;
+
+    expect(bare.buckets[0].oneSided).toBe(true);
+    expect(withNo.buckets[0].oneSided).toBe(false);
+    expect(withNo.buckets[0].confidence).toBeGreaterThan(
+      bare.buckets[0].confidence
+    );
+  });
+
+  it("accepts the query ids in any order", async () => {
+    // Buckets are sorted by bound here, so callers need not track which
+    // query_id is the bottom of the line.
+    const ordered = (await fakeAction().getMarketForecast([
+      101, 102, 103, 104, 105,
+    ]))!;
+    const shuffled = (await fakeAction().getMarketForecast([
+      103, 105, 101, 104, 102,
+    ]))!;
+
+    expect(shuffled.value).toBeCloseTo(ordered.value, 10);
+    expect(shuffled.buckets.map((b) => b.queryId)).toEqual([
+      101, 102, 103, 104, 105,
+    ]);
+  });
+
+  it("reports a gap in the bucket layout instead of hiding it", async () => {
+    // A market missing an interior bucket still gets an estimate, but the caller
+    // must be able to see that the line was not fully tiled.
+    const f = await fakeAction().getMarketForecast([101, 102, 104, 105]);
+    expect(f).not.toBeNull();
+    expect(f!.warnings.some((w) => w.includes("gap"))).toBe(true);
+  });
+
+  it("warns when the line is not open ended", async () => {
+    // Interior buckets only: nothing covers the tails, so the mass beyond them
+    // is unrepresented and the caller should know.
+    const f = (await fakeAction().getMarketForecast([102, 103, 104]))!;
+    expect(f.warnings.some((w) => w.includes("not open below"))).toBe(true);
+    expect(f.warnings.some((w) => w.includes("not open above"))).toBe(true);
+  });
+
+  it("rejects a single bucket", async () => {
+    await expect(fakeAction().getMarketForecast([103])).rejects.toThrow(
+      /at least 2/
+    );
+  });
+
+  it("rejects a market without query components", async () => {
+    // Legacy markets carry no bounds, and guessing them would be worse than
+    // failing.
+    await expect(
+      fakeAction({ queryComponents: false }).getMarketForecast([101, 102])
+    ).rejects.toThrow(/query_components/);
+  });
+
+  it("yields no forecast for an unquoted market", async () => {
+    const dead: Record<number, FakeMarket> = {};
+    for (const [id, market] of Object.entries(MSFT_MARKETS)) {
+      dead[Number(id)] = { ...market, yesBid: null, yesAsk: null };
+    }
+    expect(
+      await fakeAction({ markets: dead }).getMarketForecast(ALL_QUERY_IDS)
+    ).toBeNull();
+  });
+});

--- a/src/util/marketBuckets.ts
+++ b/src/util/marketBuckets.ts
@@ -16,6 +16,33 @@ export interface BucketBounds {
 }
 
 /**
+ * Throws when a market's query timestamp could not be read.
+ *
+ * Every binary action carries one at argument 2; only `frozenAt` is nullable. A
+ * null timestamp stringifies to `"null"` in the market identity, so two
+ * malformed markets would COLLIDE on that component and match each other — the
+ * identity check failing open in exactly the case it exists to catch. Better to
+ * refuse a market we cannot pin down than to match it by accident.
+ *
+ * Unknown action types are left alone: their layout is unknown, so argument 2
+ * need not be a timestamp at all, and {@link bucketBoundsFromMarketData} already
+ * turns them away with a clearer message.
+ *
+ * @internal Not part of the package's public surface.
+ */
+export function requireQueryTime(
+  queryId: number,
+  marketData: Pick<MarketData, "type" | "timestamp">
+): void {
+  if (marketData.type !== "unknown" && marketData.timestamp === null) {
+    throw new Error(
+      `market ${queryId} carries no readable query timestamp, so it cannot ` +
+        `be matched against the other buckets of its market`
+    );
+  }
+}
+
+/**
  * Turns one bucket market's decoded data into its `[lower, upper)` bounds.
  *
  * `null` means open-ended, which is how the outer two buckets of a market are
@@ -64,15 +91,41 @@ export function bucketBoundsFromMarketData(
       return { lower: null, upper: threshold(0) };
     case "above":
       return { lower: threshold(0), upper: null };
-    case "between":
-      return { lower: threshold(0), upper: threshold(1) };
+    case "between": {
+      const lower = threshold(0);
+      const upper = threshold(1);
+      // Bounds are half-open [lower, upper), so lower === upper is an empty
+      // bucket and lower > upper is an inverted one. Neither can hold an
+      // outcome, and both would quietly distort the tiling.
+      if (lower >= upper) {
+        throw new Error(
+          `a '${marketType}' market needs lower < upper, got [${lower}, ${upper})`
+        );
+      }
+      return { lower, upper };
+    }
     case "equals": {
       // thresholds are (target, tolerance), NOT (lower, upper). Reading them
       // positionally the way `between` is read would give an inverted bucket and
       // be silently wrong rather than loud.
       const target = threshold(0);
       const tolerance = threshold(1);
-      return { lower: target - tolerance, upper: target + tolerance };
+      if (tolerance <= 0) {
+        throw new Error(
+          `an '${marketType}' market needs a positive tolerance, got ${tolerance}`
+        );
+      }
+      const lower = target - tolerance;
+      const upper = target + tolerance;
+      // Both operands are finite, but the sum or difference can still overflow
+      // near the float limits.
+      if (!Number.isFinite(lower) || !Number.isFinite(upper)) {
+        throw new Error(
+          `an '${marketType}' market with target ${target} and tolerance ` +
+            `${tolerance} overflows its bounds`
+        );
+      }
+      return { lower, upper };
     }
     default:
       throw new Error(

--- a/src/util/marketBuckets.ts
+++ b/src/util/marketBuckets.ts
@@ -1,0 +1,73 @@
+/**
+ * Bucket bounds from a decoded prediction market's query components.
+ *
+ * SDK-side glue, deliberately kept OUT of `forecast.ts`: that module is a
+ * translation of the upstream algorithm in truflation/prediction-bots and must
+ * stay comparable against it (and against the sdk-py mirror). Nothing here is
+ * part of the forecast maths.
+ */
+
+import type { MarketData } from "./orderbookHelpers";
+
+/** One bucket's half-open `[lower, upper)` bounds; `null` means open-ended. */
+export interface BucketBounds {
+  lower: number | null;
+  upper: number | null;
+}
+
+/**
+ * Turns one bucket market's decoded data into its `[lower, upper)` bounds.
+ *
+ * `null` means open-ended, which is how the outer two buckets of a market are
+ * always struck. Bounds are half-open upstream, so a value landing exactly on a
+ * boundary resolves the upper bucket only.
+ *
+ * @param marketData - The result of {@link decodeMarketData}.
+ * @returns The bucket's bounds, either of which may be `null`.
+ * @throws If the market type cannot describe a bucket, or the thresholds needed
+ *   for that type are missing.
+ *
+ * @example
+ * ```typescript
+ * const info = await orderbook.getMarketInfo(queryId);
+ * const bounds = bucketBoundsFromMarketData(decodeMarketData(info.queryComponents));
+ * // { lower: 4.04, upper: 4.33 }
+ * ```
+ */
+export function bucketBoundsFromMarketData(
+  marketData: Pick<MarketData, "type" | "thresholds">
+): BucketBounds {
+  const marketType = marketData.type;
+  const thresholds = marketData.thresholds ?? [];
+
+  const threshold = (index: number): number => {
+    if (thresholds.length <= index) {
+      throw new Error(
+        `a '${marketType}' market needs at least ${index + 1} threshold(s), ` +
+          `got ${thresholds.length}`
+      );
+    }
+    return Number(thresholds[index]);
+  };
+
+  switch (marketType) {
+    case "below":
+      return { lower: null, upper: threshold(0) };
+    case "above":
+      return { lower: threshold(0), upper: null };
+    case "between":
+      return { lower: threshold(0), upper: threshold(1) };
+    case "equals": {
+      // thresholds are (target, tolerance), NOT (lower, upper). Reading them
+      // positionally the way `between` is read would give an inverted bucket and
+      // be silently wrong rather than loud.
+      const target = threshold(0);
+      const tolerance = threshold(1);
+      return { lower: target - tolerance, upper: target + tolerance };
+    }
+    default:
+      throw new Error(
+        `cannot derive bucket bounds from a '${marketType}' market`
+      );
+  }
+}

--- a/src/util/marketBuckets.ts
+++ b/src/util/marketBuckets.ts
@@ -117,12 +117,15 @@ export function bucketBoundsFromMarketData(
       }
       const lower = target - tolerance;
       const upper = target + tolerance;
-      // Both operands are finite, but the sum or difference can still overflow
-      // near the float limits.
-      if (!Number.isFinite(lower) || !Number.isFinite(upper)) {
+      // A positive tolerance does not guarantee a non-empty bucket. Near the
+      // float limits the sum can overflow to Infinity, and a tolerance small
+      // enough relative to the target is absorbed entirely, collapsing both
+      // edges onto the same value: 1e300 +/- 1e-300 is 1e300 twice.
+      if (!Number.isFinite(lower) || !Number.isFinite(upper) || lower >= upper) {
         throw new Error(
           `an '${marketType}' market with target ${target} and tolerance ` +
-            `${tolerance} overflows its bounds`
+            `${tolerance} does not describe a usable bucket: ` +
+            `[${lower}, ${upper})`
         );
       }
       return { lower, upper };

--- a/src/util/marketBuckets.ts
+++ b/src/util/marketBuckets.ts
@@ -47,7 +47,16 @@ export function bucketBoundsFromMarketData(
           `got ${thresholds.length}`
       );
     }
-    return Number(thresholds[index]);
+    const value = Number(thresholds[index]);
+    if (!Number.isFinite(value)) {
+      // Number("abc") is NaN, which would flow all the way into the forecast
+      // and surface as a NaN value rather than as this market being unreadable.
+      throw new Error(
+        `threshold ${index} of a '${marketType}' market is not a number: ` +
+          `'${thresholds[index]}'`
+      );
+    }
+    return value;
   };
 
   switch (marketType) {

--- a/src/util/orderbookHelpers.ts
+++ b/src/util/orderbookHelpers.ts
@@ -22,6 +22,16 @@ export interface MarketData {
   actionId: string;
   type: "above" | "below" | "between" | "equals" | "unknown";
   thresholds: string[];
+  /**
+   * The point in the stream the query observes, in unix seconds. Every bucket
+   * of one market shares it; null only when the arguments could not be read.
+   */
+  timestamp: number | null;
+  /**
+   * The block height the data is pinned to. Encoded as NULL to mean "latest",
+   * so null is a real value rather than a decode failure.
+   */
+  frozenAt: number | null;
 }
 
 /**
@@ -47,6 +57,27 @@ export function decodeMarketData(encoded: string | Uint8Array): MarketData {
     actionId,
     type: "unknown",
     thresholds: [],
+    timestamp: null,
+    frozenAt: null,
+  };
+
+  /** INT8 arguments arrive as bigint, and NULL is a value rather than an error. */
+  const argInt = (index: number): number | null => {
+    if (index >= args.length) return null;
+    const value = args[index];
+    if (value === null || value === undefined) return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  };
+
+  /**
+   * Every binary action takes ($data_provider, $stream_id, $timestamp, ...,
+   * $frozen_at), so the timestamp is always argument 2 and frozen_at is always
+   * last. Only the thresholds in between change shape.
+   */
+  const readQueryTime = (frozenAtIndex: number): void => {
+    market.timestamp = argInt(2);
+    market.frozenAt = argInt(frozenAtIndex);
   };
 
   // Map action_id to market type and thresholds
@@ -57,24 +88,28 @@ export function decodeMarketData(encoded: string | Uint8Array): MarketData {
       if (args.length >= 4) {
         market.thresholds.push(args[3].toString());
       }
+      readQueryTime(4);
       break;
     case "price_below_threshold":
       market.type = "below";
       if (args.length >= 4) {
         market.thresholds.push(args[3].toString());
       }
+      readQueryTime(4);
       break;
     case "value_in_range":
       market.type = "between";
       if (args.length >= 5) {
         market.thresholds.push(args[3].toString(), args[4].toString());
       }
+      readQueryTime(5);
       break;
     case "value_equals":
       market.type = "equals";
       if (args.length >= 5) {
         market.thresholds.push(args[3].toString(), args[4].toString());
       }
+      readQueryTime(5);
       break;
   }
 

--- a/src/util/orderbookHelpers.ts
+++ b/src/util/orderbookHelpers.ts
@@ -76,6 +76,13 @@ export function decodeMarketData(encoded: string | Uint8Array): MarketData {
    * last. Only the thresholds in between change shape.
    */
   const readQueryTime = (frozenAtIndex: number): void => {
+    // Both slots have to exist for either to mean anything. A truncated
+    // argument list would otherwise leave frozenAt null, which is
+    // indistinguishable from the explicit ABI NULL that every well-formed
+    // market carries to mean "latest" — so a malformed market would match a
+    // healthy one on that component of its identity. Leaving timestamp null
+    // instead hands the whole market to the caller's readability check.
+    if (args.length <= frozenAtIndex) return;
     market.timestamp = argInt(2);
     market.frozenAt = argInt(frozenAtIndex);
   };

--- a/tests/integration/marketForecast.test.ts
+++ b/tests/integration/marketForecast.test.ts
@@ -92,11 +92,14 @@ async function discoverGroups(
 
     for (const market of page) {
       scanned += 1;
+      // Outside the try on purpose: a transport or node failure is a real
+      // problem and must fail the run, not quietly shrink the candidate set.
+      const info = await orderbook.getMarketInfo(market.id);
+      if (!info.queryComponents || info.queryComponents.length === 0) continue;
+
       let candidate: Candidate;
       let key: string;
       try {
-        const info = await orderbook.getMarketInfo(market.id);
-        if (!info.queryComponents || info.queryComponents.length === 0) continue;
         const marketData = decodeMarketData(info.queryComponents);
         const bounds = bucketBoundsFromMarketData(marketData);
         candidate = {

--- a/tests/integration/marketForecast.test.ts
+++ b/tests/integration/marketForecast.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Live-network checks that the SDK reads real order books the right way round.
+ *
+ * Everything else in the forecast suite feeds the algorithm hand-written
+ * numbers, which proves the maths but cannot prove the SDK is reading the CHAIN
+ * correctly. If the node ever flipped the sign convention on bids, every one of
+ * those tests would still pass while the forecast silently inverted. That is the
+ * gap this file covers.
+ *
+ * Gated, because it needs the network and live markets carrying real orders:
+ *
+ *     TEST_MAINNET_ENDPOINT=https://gateway.mainnet.truf.network \
+ *     TEST_MAINNET_CHAIN_ID=tn-v2.1 \
+ *     npx vitest run tests/integration/marketForecast.test.ts
+ *
+ * All calls are view actions, so the signing wallet needs no funds and controls
+ * nothing; a throwaway is generated.
+ *
+ * These assert SHAPES, not numbers. Live books move minute to minute, so pinning
+ * an expected value would fail by tomorrow. Exact numbers belong in the unit
+ * tests. A wrong FORMULA will pass here quite happily — this only proves the
+ * plumbing between the SDK and the chain is connected the right way round.
+ */
+
+import { describe, test, expect, beforeAll } from "vitest";
+import { Wallet } from "ethers";
+import { NodeTNClient } from "../../src/client/nodeClient";
+import type { OrderbookAction } from "../../src/contracts-api/orderbookAction";
+import type {
+  BookLevel,
+  BucketEstimate,
+  MarketForecast,
+} from "../../src/util/forecast";
+import { bucketBoundsFromMarketData } from "../../src/util/marketBuckets";
+import { decodeMarketData } from "../../src/util/orderbookHelpers";
+
+// Discovery costs one call per open market, so it is bounded. Mainnet carried
+// ~110 open markets when this was written; the cap is headroom, not a target.
+const MAX_MARKETS_SCANNED = 500;
+
+// Candidate groups to probe for quotes before giving up. A market can tile the
+// line perfectly and still have nobody quoting it, which is not a code defect,
+// so candidates are ranked by how much of the line is actually quoted rather
+// than by bucket count alone -- most open markets carry no orders at all.
+const MAX_GROUPS_PROBED = 25;
+
+// Below this many quoted buckets the forecast rests on residuals more than on
+// orders, which is not what this test is trying to exercise.
+const MIN_QUOTED_BUCKETS = 2;
+
+const endpoint = process.env.TEST_MAINNET_ENDPOINT;
+const chainId = process.env.TEST_MAINNET_CHAIN_ID;
+const configured = Boolean(endpoint && chainId);
+
+interface Candidate {
+  queryId: number;
+  type: string;
+  lower: number | null;
+  upper: number | null;
+}
+
+/** One bucket open below, one open above, at least one in between. */
+function tilesTheLine(members: Candidate[]): boolean {
+  const types = members.map((m) => m.type);
+  return (
+    members.length >= 3 &&
+    types.filter((t) => t === "below").length === 1 &&
+    types.filter((t) => t === "above").length === 1
+  );
+}
+
+/**
+ * Every open market, grouped into candidate bucket sets.
+ *
+ * A market's buckets share a data stream and a settlement time, which is enough
+ * to reassemble them from chain data alone — no local config needed.
+ */
+async function discoverGroups(
+  orderbook: OrderbookAction
+): Promise<Candidate[][]> {
+  const groups = new Map<string, Candidate[]>();
+  let offset = 0;
+  let scanned = 0;
+
+  while (scanned < MAX_MARKETS_SCANNED) {
+    const page = await orderbook.listMarkets({
+      settledFilter: false,
+      limit: 100,
+      offset,
+    });
+    if (!page.length) break;
+
+    for (const market of page) {
+      scanned += 1;
+      let candidate: Candidate;
+      let key: string;
+      try {
+        const info = await orderbook.getMarketInfo(market.id);
+        if (!info.queryComponents || info.queryComponents.length === 0) continue;
+        const marketData = decodeMarketData(info.queryComponents);
+        const bounds = bucketBoundsFromMarketData(marketData);
+        candidate = {
+          queryId: market.id,
+          type: marketData.type,
+          ...bounds,
+        };
+        key = `${marketData.streamId}@${market.settleTime}`;
+      } catch {
+        // Legacy or non-bucket markets: not what this test is about.
+        continue;
+      }
+      const existing = groups.get(key);
+      if (existing) existing.push(candidate);
+      else groups.set(key, [candidate]);
+    }
+
+    if (page.length < 100) break;
+    offset += 100;
+  }
+
+  // Widest first: more buckets means more of the line actually quoted.
+  return [...groups.values()]
+    .filter(tilesTheLine)
+    .sort((a, b) => b.length - a.length);
+}
+
+/**
+ * The bucket where the implied CDF crosses 50%.
+ *
+ * NOT the most probable bucket: with probabilities [0.40, 0.35, 0.25] the leader
+ * is the first, but the cumulative only reaches half way through the second, so
+ * that is where the median belongs.
+ */
+function medianBucket(forecast: MarketForecast): BucketEstimate {
+  let running = 0;
+  for (const bucket of forecast.buckets) {
+    running += bucket.probability;
+    if (running >= 0.5) return bucket;
+  }
+  return forecast.buckets[forecast.buckets.length - 1];
+}
+
+describe.skipIf(!configured)(
+  "Market Forecast Live Integration Tests",
+  { timeout: 600000 },
+  () => {
+    let orderbook: OrderbookAction;
+    let queryIds: number[] | null = null;
+    let forecast: MarketForecast | null = null;
+    let skipReason = "";
+
+    beforeAll(async () => {
+      // Read-only suite: a fresh random wallet is sufficient and avoids
+      // committing a private key. Every action used here is a view action.
+      const wallet = Wallet.createRandom();
+      const client = new NodeTNClient({
+        endpoint: endpoint!,
+        signerInfo: { address: wallet.address, signer: wallet },
+        chainId: chainId!,
+        timeout: 30000,
+      });
+      orderbook = client.loadOrderbookAction();
+
+      const candidates = await discoverGroups(orderbook);
+      if (!candidates.length) {
+        skipReason = "no open market on this network currently tiles the line";
+        return;
+      }
+
+      // One cheap call per bucket to find where the orders are. Ranking on this
+      // rather than on bucket count matters: most open markets tile the line
+      // perfectly and carry no orders whatsoever.
+      const ranked: { quoted: number; newest: number; ids: number[] }[] = [];
+      for (const members of candidates.slice(0, MAX_GROUPS_PROBED)) {
+        const ids = members.map((m) => m.queryId);
+        let quoted = 0;
+        for (const queryId of ids) {
+          const best = await orderbook.getBestPrices(queryId, true);
+          if (best.bestBid !== null || best.bestAsk !== null) quoted += 1;
+        }
+        if (quoted >= MIN_QUOTED_BUCKETS) {
+          ranked.push({ quoted, newest: Math.max(...ids), ids });
+        }
+      }
+
+      if (!ranked.length) {
+        skipReason =
+          `no market among ${Math.min(candidates.length, MAX_GROUPS_PROBED)} ` +
+          `tiling candidates had ${MIN_QUOTED_BUCKETS}+ quoted buckets`;
+        return;
+      }
+
+      // Most quoted first, then newest. Recency is only a tie-break: settled
+      // markets are already excluded, and on mainnet the newest markets are
+      // routinely the ones with no orders yet, so it is a poor primary signal.
+      ranked.sort((a, b) => b.quoted - a.quoted || b.newest - a.newest);
+      for (const { ids } of ranked) {
+        const result = await orderbook.getMarketForecast(ids);
+        if (result !== null) {
+          queryIds = ids;
+          forecast = result;
+          return;
+        }
+      }
+      skipReason = "quoted markets found, but none yielded a usable forecast";
+    });
+
+    /** Guards every test: an empty book is a fact about the day, not a defect. */
+    function live(): { queryIds: number[]; forecast: MarketForecast } | null {
+      if (forecast === null) {
+        console.warn(`skipping: ${skipReason}`);
+        return null;
+      }
+      return { queryIds: queryIds!, forecast };
+    }
+
+    test("a real market produces a forecast", () => {
+      const it = live();
+      if (!it) return;
+
+      expect(it.queryIds.length).toBeGreaterThanOrEqual(3);
+      expect(Number.isNaN(it.forecast.value)).toBe(false);
+      expect(["rank", "discrete"]).toContain(it.forecast.method);
+      expect(["interior", "tail", "unresolved"]).toContain(
+        it.forecast.valueBasis
+      );
+    });
+
+    test("the probabilities form a distribution", () => {
+      const it = live();
+      if (!it) return;
+
+      const probabilities = it.forecast.buckets.map((b) => b.probability);
+      expect(probabilities.every((p) => p >= 0 && p <= 1)).toBe(true);
+      expect(probabilities.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 9);
+    });
+
+    test("the value falls in the bucket where the CDF crosses half", () => {
+      // The point estimate is the median, so it must land in the median bucket.
+      // This is the assertion that would catch a bounds-derivation or ordering
+      // mistake: get the buckets in the wrong order and the value lands in the
+      // wrong one.
+      const it = live();
+      if (!it) return;
+      if (it.forecast.valueBasis === "unresolved") {
+        console.warn("skipping: median unresolvable from this market's strikes");
+        return;
+      }
+
+      const bucket = medianBucket(it.forecast);
+      if (bucket.lower !== null) {
+        expect(it.forecast.value).toBeGreaterThanOrEqual(bucket.lower);
+      }
+      if (bucket.upper !== null) {
+        expect(it.forecast.value).toBeLessThanOrEqual(bucket.upper);
+      }
+    });
+
+    test("the band brackets the value", () => {
+      const it = live();
+      if (!it) return;
+      if (it.forecast.p10 === null || it.forecast.p90 === null) {
+        console.warn("skipping: band unresolvable from this market's strikes");
+        return;
+      }
+
+      expect(it.forecast.p10).toBeLessThanOrEqual(it.forecast.value);
+      expect(it.forecast.value).toBeLessThanOrEqual(it.forecast.p90);
+      expect(it.forecast.marginOfError).toBeGreaterThan(0);
+    });
+
+    test("the buckets are ordered and tile the line", () => {
+      // Assembly must hand the algorithm an ascending, gap-free ladder.
+      const it = live();
+      if (!it) return;
+
+      const buckets = it.forecast.buckets;
+      expect(buckets[0].lower).toBeNull();
+      expect(buckets[buckets.length - 1].upper).toBeNull();
+      for (let i = 0; i + 1 < buckets.length; i++) {
+        expect(buckets[i].upper).toBe(buckets[i + 1].lower);
+      }
+    });
+
+    test("the bid sign convention still holds", async () => {
+      // The canary.
+      //
+      // getOrderBook marks bids with a NEGATIVE price; getBestPrices reports the
+      // same bid as POSITIVE. Two independent node paths for one fact, so if
+      // either convention ever changes they stop agreeing here — loudly —
+      // instead of silently inverting every one-sided bucket in the forecast.
+      const it = live();
+      if (!it) return;
+
+      // Reaches the private converter on purpose: re-deriving the ladders here
+      // would only test this file's copy of the rule, and the rule is exactly
+      // what is under suspicion. This also pins the Number() coercion — the node
+      // sends `amount` as a NUMERIC, which arrives as a string.
+      const ladders = orderbook as unknown as {
+        orderBookLadders(
+          queryId: number,
+          outcome: boolean
+        ): Promise<{ bids: BookLevel[]; asks: BookLevel[] }>;
+      };
+
+      let checked = 0;
+      for (const queryId of it.queryIds) {
+        for (const outcome of [true, false]) {
+          const { bids, asks } = await ladders.orderBookLadders(
+            queryId,
+            outcome
+          );
+          const best = await orderbook.getBestPrices(queryId, outcome);
+
+          for (const level of [...bids, ...asks]) {
+            expect(typeof level.price).toBe("number");
+            expect(typeof level.size).toBe("number");
+            expect(level.price).toBeGreaterThan(0);
+            expect(level.price).toBeLessThan(100);
+            expect(level.size).toBeGreaterThan(0);
+          }
+
+          // Number() is load-bearing, not defensive tidying: get_best_prices
+          // returns its prices as NUMERIC, so they arrive as STRINGS despite
+          // BestPrices typing them `number | null`. Comparing them raw makes
+          // this assertion fail on a book that is perfectly correct.
+          if (bids.length && best.bestBid !== null) {
+            expect(Math.max(...bids.map((l) => l.price))).toBe(
+              Number(best.bestBid)
+            );
+            checked += 1;
+          }
+          if (asks.length && best.bestAsk !== null) {
+            expect(Math.min(...asks.map((l) => l.price))).toBe(
+              Number(best.bestAsk)
+            );
+            checked += 1;
+          }
+        }
+      }
+
+      if (!checked) {
+        console.warn(
+          "skipping: no resting orders to cross-check the sign convention against"
+        );
+      }
+    });
+  }
+);


### PR DESCRIPTION
## Summary

Ports the market-implied point forecast from `sdk-py` to `sdk-js`, so both SDKs
expose the same capability and return the same numbers.

Prediction markets price **ranges**: a five-bucket EPS market says "34% chance
EPS lands between $2.06 and $2.21", never "EPS will be $2.14". This inverts
that, collapsing the order books across every bucket of one market into the
single number they collectively imply, plus the band around it.

```
market says                     ->  forecast says
"34% between 2.06 and 2.21"         "2.14, p10..p90 1.91..2.38"
```

## What's in it

| Purpose | File |
|---|---|
| The algorithm (pure, no I/O) | `src/util/forecast.ts` (new) |
| Bucket bounds from decoded market data | `src/util/marketBuckets.ts` (new) |
| `orderbook.getMarketForecast(queryIds)` | `src/contracts-api/orderbookAction.ts` |
| Public exports | `src/internal.ts` |
| Docs | `docs/api-reference.md` |

Three commits, scoped for a clean squash body: `feat:` (algorithm + client +
unit tests), `test:` (live integration suite), `docs:`.

### Mapping to sdk-py

| sdk-py | sdk-js |
|---|---|
| `forecast.py` | `src/util/forecast.ts` |
| `market_buckets.py` | `src/util/marketBuckets.ts` |
| `client.get_market_forecast` | `orderbook.getMarketForecast` |

Names are camelCased, and Python's dataclass methods become free functions
(`consolidatedBids`, `bestView`, `forecastToJSON`) so callers build inputs as
plain object literals instead of positional constructors.

`getMarketForecast` reads **both** the YES and NO books per bucket. On this
venue a resting BUY NO at *p* is hittable by a BUY YES at *100-p* (mint match),
so NO liquidity is executable YES liquidity — ignoring it would discard real
quotes. That is why the call costs three reads per bucket rather than two.

## Provenance and why this is a translation, not a copy

The algorithm comes from `truflation/prediction-bots` @ `main 21fe4f3` (PR #37),
whose last change to the file was `fafe52b`, by way of the byte-identical mirror
in `sdk-py`.

`sdk-py` can keep a verbatim copy and re-sync with a `diff`. TypeScript cannot,
so drift here has to be caught by **behaviour** instead: `forecast.test.ts` and
`forecastDepth.test.ts` are ports of the upstream suites, including the frozen
live NVDA book from issue #36. Change the algorithm upstream first, then port it
here and re-run both suites.

## Verification

Passing a ported test suite only proves the tests were ported too, so parity was
checked directly against `sdk-py`.

**Shared case set** — 39 cases through both implementations: best-quote and
depth paths, open tails, the discrete fallback, dutch books, crossed touches,
dust griefing, the frozen NVDA book. All **2212 leaf values** agree, warning
strings included.

**Live mainnet** — the same NVDA market (`419-423`) read once and run through
both. `value`, `p10`, `p90`, `marginOfError` and `sigma` came back
**bit-identical**: value `2.1362`, band `1.9053..2.3792`.

### The one residual, stated plainly

At zero tolerance the two differ by ~1e-16, worst case 6.5 ULP. Single cause:
CPython 3.12 gave `sum()` compensated (Neumaier) summation for floats, so the
Python sums are slightly *more* accurate than the plain left-to-right ones here.

Reproducing it would mean a compensated adder at every sum site, coupling this
file to a CPython implementation detail that upstream's source does not state —
it just says `sum(...)` — and making the translation harder to read against the
original, which is the whole maintenance strategy. Not worth it for a difference
fourteen orders of magnitude below the published margin of error.

It is not *entirely* invisible: a sum landing within 1e-16 of a rounding
boundary can move the last digit of a warning **string**. On the live read above
Python summed to `1.0725` and this to `1.0724999999999998`, printing `"1.073"`
against `"1.072"`. Forecast numbers unaffected. Documented in the file header so
a future re-verification does not read it as a bug.

## Bug found while wiring this up

The live suite caught a real defect, twice:

- `getOrderBook` returns `amount` as a **string** (NUMERIC over the wire),
  despite `OrderBookEntry` typing it `number`.
- `getBestPrices` does the same for `bestBid` / `bestAsk`.

`sdk-py` casts with `float()`; I had dropped that. Left uncoerced it *survives*
multiplication — JS coerces — but turns `+=` into string concatenation, so it
would have stayed hidden until some future reader of the ladder summed sizes.
Fixed with `Number()` inside `orderBookLadders`.

**The public parsers are deliberately untouched.** `getOrderBook` and
`getBestPrices` still return strings against a `number` type. That is
pre-existing, and correcting it changes values already-shipped consumers
receive, which is wider than this PR. Worth a follow-up: on raw strings a
`bestBid > bestAsk` check compares `"9" > "10"` as **true**.

## Deliberate omission

Upstream still carries `_fit_normal`, the weighted-least-squares normal fit on
the probit scale that the rank method replaced. Nothing calls it — it is
unreachable there — so it is not translated. That also spares this file an
inverse-normal CDF, which JavaScript has no standard-library answer for. Noted
in the header: if it is ever rewired upstream it must be written here from
scratch, not ported.

## Testing

- **389 unit tests pass** (57 new). `tsc --noEmit` clean.
- **6 env-gated live tests pass against mainnet.** They skip cleanly without
  `TEST_MAINNET_ENDPOINT` / `TEST_MAINNET_CHAIN_ID`, and were run *configured* —
  a gate that always skips proves nothing, and running it is what surfaced the
  string-coercion bug above.

```bash
TEST_MAINNET_ENDPOINT=https://gateway.mainnet.truf.network \
TEST_MAINNET_CHAIN_ID=tn-v2.1 \
npx vitest run tests/integration/marketForecast.test.ts
```

The live suite asserts **shapes, not numbers** — live books move minute to
minute, so a pinned value would fail by tomorrow. Exact numbers live in the unit
tests. Its job is proving the SDK reads the chain the right way round; the
canary cross-checks `getOrderBook`'s negative-price bid convention against
`getBestPrices`' positive one, two independent node paths for one fact.

## Notes for reviewers

- `marginOfError` is **half the P10..P90 band, not a standard error**. It says
  how uncertain the *outcome* is, not how tightly the book pins the estimate.
  Expect ~0.24 against a value of 2.14 on a live EPS market. Documented, because
  it is the field most likely to be misread downstream.
- Bucket reads are **sequential**, matching `sdk-py`. `Promise.all` would be
  faster but fires 3N concurrent gateway calls; happy to change if preferred.
- Warning strings are matched to Python's formatting, including round-half-even
  tie behaviour (`halfToEven`) — `toFixed` breaks ties away from zero, which
  otherwise printed "63%" here against "62%" in `sdk-py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added market forecasts from prediction-market bucket prices and order-book depth.
  - Added point estimates, percentile ranges, uncertainty details, confidence indicators, warnings, bucket probabilities, and multimodality information.
  - Added forecast discovery by market query IDs, with validation and no-result handling.
  - Added support for YES/NO liquidity, one-sided books, and open-ended market buckets.
  - Added helpers for forecast generation, serialization, and deriving bucket boundaries from market metadata.
  - Added timestamp and freeze-time metadata to market data.
- **Documentation**
  - Added comprehensive API reference documentation for market forecasting and related data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->