### PR TITLE
chore: keep MarketData constructible by existing consumers

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1384,9 +1384,9 @@ interface MarketData {
 Lists markets with optional filtering.
 
 ```typescript
-// Get all unsettled markets
+// Get all settled markets
 const markets = await orderbook.listMarkets({
-  settledFilter: true, // true=unsettled, false=settled, null=all
+  settledFilter: true, // true=settled, false=active, null=all
   limit: 100,
   offset: 0,
 });

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -168,7 +168,11 @@ export {
   decodeCreateMarketPayload,
 } from "./util/orderbookHelpers";
 
-export type { MarketData, CreateMarketPayload } from "./util/orderbookHelpers";
+export type {
+  MarketData,
+  DecodedMarketData,
+  CreateMarketPayload,
+} from "./util/orderbookHelpers";
 
 // Market forecasting: the single value a market's bucket order books imply.
 export {

--- a/src/types/orderbook.ts
+++ b/src/types/orderbook.ts
@@ -311,8 +311,11 @@ export interface ListMarketsInput {
   /**
    * Filter by settlement status:
    * - null/undefined: All markets
-   * - true: Unsettled markets only
-   * - false: Settled markets only
+   * - true: Settled markets only
+   * - false: Active (unsettled) markets only
+   *
+   * The value passes straight through to `list_markets`, which filters on
+   * `WHERE settled = $settled_filter`.
    */
   settledFilter?: boolean | null;
   /** Maximum number of markets to return */

--- a/src/util/marketBuckets.test.ts
+++ b/src/util/marketBuckets.test.ts
@@ -172,6 +172,16 @@ describe("requireQueryTime", () => {
     );
   });
 
+  it("rejects a market that omits the timestamp entirely", () => {
+    // `timestamp` is optional on MarketData so hand-built objects still
+    // compile. An object that leaves it out is exactly as unpinnable as one
+    // that decoded to null, so it has to fail the same way rather than
+    // slipping through as "undefined" in the identity string.
+    expect(() => requireQueryTime(101, { type: "below" })).toThrow(
+      /no readable query timestamp/
+    );
+  });
+
   it("accepts a readable timestamp", () => {
     expect(() =>
       requireQueryTime(101, { type: "below", timestamp: 1700000000 })

--- a/src/util/marketBuckets.ts
+++ b/src/util/marketBuckets.ts
@@ -34,7 +34,10 @@ export function requireQueryTime(
   queryId: number,
   marketData: Pick<MarketData, "type" | "timestamp">
 ): void {
-  if (marketData.type !== "unknown" && marketData.timestamp === null) {
+  // `== null` on purpose: it catches undefined as well as null. `timestamp` is
+  // optional on MarketData so hand-built objects still compile, and one that
+  // omits it is exactly as unpinnable as one that decoded to null.
+  if (marketData.type !== "unknown" && marketData.timestamp == null) {
     throw new Error(
       `market ${queryId} carries no readable query timestamp, so it cannot ` +
         `be matched against the other buckets of its market`

--- a/src/util/orderbookHelpers.ts
+++ b/src/util/orderbookHelpers.ts
@@ -25,13 +25,18 @@ export interface MarketData {
   /**
    * The point in the stream the query observes, in unix seconds. Every bucket
    * of one market shares it; null only when the arguments could not be read.
+   *
+   * Optional so that code building a MarketData by hand — fixtures, mocks,
+   * anything predating the forecast API — still compiles. `decodeMarketData`
+   * always sets it, so a value read from the chain is never undefined.
    */
-  timestamp: number | null;
+  timestamp?: number | null;
   /**
    * The block height the data is pinned to. Encoded as NULL to mean "latest",
-   * so null is a real value rather than a decode failure.
+   * so null is a real value rather than a decode failure. Optional for the
+   * same reason as `timestamp`.
    */
-  frozenAt: number | null;
+  frozenAt?: number | null;
 }
 
 /**

--- a/src/util/orderbookHelpers.ts
+++ b/src/util/orderbookHelpers.ts
@@ -606,7 +606,7 @@ export function validateSettleTime(settleTime: number): void {
 /**
  * Converts settled filter boolean to the value for Kuneiform.
  *
- * @param filter - Boolean filter (null/undefined=all, true=unsettled, false=settled)
+ * @param filter - Boolean filter (null/undefined=all, true=settled, false=active)
  * @returns Boolean or null (null=all, true/false=filter by settled status)
  */
 export function settledFilterToBoolean(
@@ -615,5 +615,5 @@ export function settledFilterToBoolean(
   if (filter === null || filter === undefined) {
     return null; // All markets
   }
-  return filter; // true=unsettled, false=settled
+  return filter; // passed to `WHERE settled = $settled_filter`
 }

--- a/src/util/orderbookHelpers.ts
+++ b/src/util/orderbookHelpers.ts
@@ -26,9 +26,10 @@ export interface MarketData {
    * The point in the stream the query observes, in unix seconds. Every bucket
    * of one market shares it; null only when the arguments could not be read.
    *
-   * Optional so that code building a MarketData by hand — fixtures, mocks,
-   * anything predating the forecast API — still compiles. `decodeMarketData`
-   * always sets it, so a value read from the chain is never undefined.
+   * Optional here so that code building a MarketData by hand — fixtures, mocks,
+   * anything predating the forecast API — still compiles. Anything that came
+   * out of {@link decodeMarketData} is a {@link DecodedMarketData}, where it is
+   * required and needs no undefined check.
    */
   timestamp?: number | null;
   /**
@@ -37,6 +38,17 @@ export interface MarketData {
    * same reason as `timestamp`.
    */
   frozenAt?: number | null;
+}
+
+/**
+ * A {@link MarketData} that came off the chain rather than being built by hand.
+ *
+ * `decodeMarketData` always populates the time fields, so callers reading a
+ * decoded market get `number | null` and never have to rule out `undefined`.
+ */
+export interface DecodedMarketData extends MarketData {
+  timestamp: number | null;
+  frozenAt: number | null;
 }
 
 /**
@@ -51,12 +63,12 @@ export interface MarketData {
  * console.log(`Market type: ${market.type}, Threshold: ${market.thresholds[0]}`);
  * ```
  */
-export function decodeMarketData(encoded: string | Uint8Array): MarketData {
+export function decodeMarketData(encoded: string | Uint8Array): DecodedMarketData {
   const bytes = dbBytesToUint8Array(encoded);
   const { dataProvider, streamId, actionId, args: argsBytes } = decodeQueryComponents(bytes);
   const args = decodeActionArgs(argsBytes);
 
-  const market: MarketData = {
+  const market: DecodedMarketData = {
     dataProvider,
     streamId,
     actionId,
@@ -143,7 +155,7 @@ export interface CreateMarketPayload {
    * be decoded — a committed-but-execution-failed create_market can carry empty/garbage
    * query_components, and an explorer should still see the top-level fields.
    */
-  market: MarketData | null;
+  market: DecodedMarketData | null;
   /** Unix timestamp at which the market settles. */
   settleTime: number;
   /** Maximum bid-ask spread allowed, in cents. */
@@ -200,7 +212,7 @@ export function decodeCreateMarketPayload(
     queryComponents as string | Uint8Array
   );
 
-  let market: MarketData | null;
+  let market: DecodedMarketData | null;
   try {
     market = decodeMarketData(queryComponentsBytes);
   } catch {


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4401

Follow-up to the review on #171. Three items, each in its own commit.

The line-ending normalisation that was originally bundled here now lives in its
own PR, so this one is 31 lines of content.

## Consumers can build a MarketData again

`timestamp` and `frozenAt` landed on the exported `MarketData` as required
fields, so any code constructing one as an object literal stopped compiling on
upgrade. Fixtures and mocks are the usual casualties. Both are optional now.
`decodeMarketData` always sets them, so anything read from the chain is
unaffected.

`requireQueryTime` compares with `== null` so an omitted field is refused the
same way a null one is. A hand-built object that leaves the timestamp out is
exactly as unpinnable as one that decoded to null, and letting it through would
put the string `"undefined"` in the identity, where two of them would match each
other. Covered by a test that fails against the old `=== null`.

## settledFilter is documented the way the node actually behaves

`list_markets` filters on `WHERE settled = $settled_filter`, so `true` returns
settled markets and `false` returns active ones. The JSDoc on `ListMarketsInput`,
the example comment, and `settledFilterToBoolean` all had it inverted, while the
forecast example added in #171 used the correct polarity, so the file
contradicted itself. sdk-go and sdk-py already documented it correctly.

Comments only. The value passes straight through, so no runtime behaviour
changes.

## Testing

405 unit tests pass, `tsc --noEmit` clean.