### PR TITLE
feat: read one order book that includes complementary quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,13 @@ await client.waitForTx(result.data!.tx_hash);
 // Get best prices
 const prices = await orderbook.getBestPrices(market.id, true);
 console.log(`YES: Bid=${prices.bestBid}c, Ask=${prices.bestAsk}c`);
+
+// Get every quote the chain will fill, including the NO book inverted into
+// the YES frame (a resting SELL NO at 93c is a hittable YES bid at 7c)
+const book = await orderbook.getConsolidatedOrderBook(market.id, true);
+for (const level of book.asks) {
+  console.log(`${level.price}c: ${level.total} (${level.native} direct, ${level.inverse} mint)`);
+}
 ```
 
 #### Market Making with Split Limit Orders
@@ -532,6 +539,7 @@ For other bundlers or serverless platforms, consult their documentation on modul
 | Place buy order | `orderbook.placeBuyOrder({queryId, outcome, price, amount})` |
 | Place split limit order | `orderbook.placeSplitLimitOrder({queryId, truePrice, amount})` |
 | Get order book | `orderbook.getOrderBook(queryId, outcome)` |
+| Get consolidated order book | `orderbook.getConsolidatedOrderBook(queryId, outcome)` |
 | Get best prices | `orderbook.getBestPrices(queryId, outcome)` |
 | Destroy stream | `client.destroyStream(streamLocator)` |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1500,17 +1500,19 @@ Gets one outcome's book with the opposite outcome's quotes folded in, so you see
 every quote the chain will actually fill.
 
 The two books of a binary market are two views of one position. A resting SELL NO
-at 93c lets someone buy YES at 7c, and the matching engine executes it by burning
-the share pair. In the YES frame:
+at 93c is a standing **bid** for YES at 7c: a trader hits it by **selling** YES,
+both sides sell, and the matching engine burns the share pair. In the YES frame:
 
-```
+```text
 consolidated bids = YES bids + (100 - p for every NO ask)
 consolidated asks = YES asks + (100 - p for every NO bid)
 ```
 
 The sides swap: a NO ask arrives as a YES bid. `outcome` defaults to `true`, and
 the NO-framed book is the YES-framed book reflected. Costs two `getMarketDepth`
-reads, issued together.
+reads. They are issued together, but the node exposes no way to pin both to one
+block, so on a moving book the two sides can come from adjacent heights and
+`isCrossed` is best-effort.
 
 ```typescript
 const book = await orderbook.getConsolidatedOrderBook(queryId);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1494,6 +1494,43 @@ for (const level of depth) {
 }
 ```
 
+#### `orderbook.getConsolidatedOrderBook(queryId: number, outcome?: boolean): Promise<ConsolidatedOrderBook>`
+
+Gets one outcome's book with the opposite outcome's quotes folded in, so you see
+every quote the chain will actually fill.
+
+The two books of a binary market are two views of one position. A resting SELL NO
+at 93c lets someone buy YES at 7c, and the matching engine executes it by burning
+the share pair. In the YES frame:
+
+```
+consolidated bids = YES bids + (100 - p for every NO ask)
+consolidated asks = YES asks + (100 - p for every NO bid)
+```
+
+The sides swap: a NO ask arrives as a YES bid. `outcome` defaults to `true`, and
+the NO-framed book is the YES-framed book reflected. Costs two `getMarketDepth`
+reads, issued together.
+
+```typescript
+const book = await orderbook.getConsolidatedOrderBook(queryId);
+for (const level of book.asks) {
+  console.log(`${level.price}c: ${level.total} shares (${level.native} direct, ${level.inverse} mint)`);
+}
+if (book.isCrossed) console.log("best bid is at or above best ask");
+```
+
+**This is not a sweepable ladder.** A direct same-outcome match crosses prices,
+but mint and burn fire only when the two prices sum to exactly 100. So one order
+fills every native level past its limit plus exactly **one** inverse level.
+Walking these levels the way you would walk `getMarketDepth` quotes fills the
+chain will not produce, which is why each level keeps `native` and `inverse`
+separate rather than only their sum.
+
+A consolidated book can also sit crossed indefinitely: a YES bid at 61 against a
+NO bid at 45 shows a bid at 61 over an ask at 55, and 61 + 45 is not 100 so
+nothing matches. Render it rather than treating it as bad data.
+
 #### `orderbook.getUserPositions(): Promise<UserPosition[]>`
 
 Gets the caller's positions across all markets.

--- a/src/contracts-api/orderbookAction.test.ts
+++ b/src/contracts-api/orderbookAction.test.ts
@@ -1,6 +1,7 @@
 import { KwilSigner, NodeKwil } from "@trufnetwork/kwil-js";
 import { describe, it, expect, vi } from "vitest";
 import { OrderbookAction } from "./orderbookAction";
+import type { ConsolidatedLevel } from "../types/orderbook";
 
 /**
  * Pure-unit tests for the address-parameterized portfolio getters (migration 051):
@@ -150,5 +151,168 @@ describe("OrderbookAction.getCollateralByWallet", () => {
     await expect(action.getCollateralByWallet(wallet, "hoodi_tt2")).rejects.toThrow(
       "Failed to get collateral by wallet: 503",
     );
+  });
+});
+
+/**
+ * getConsolidatedOrderBook: the two outcome books folded into the one ladder a
+ * trader can actually hit. The mapping is arithmetic on two get_market_depth
+ * reads, so it is fully testable against a mocked client. What matters is that
+ * the SIDES swap (a NO ask is a YES bid, not a YES ask) and that each level
+ * keeps its native/inverse split, since mint and burn only fire at the exact
+ * complement and a caller quoting a fill needs to know which is which.
+ */
+
+/** One depth row as get_market_depth returns it: price plus both volumes. */
+type DepthRow = { price: number; buy?: number; sell?: number };
+
+function makeDepthAction(books: { yes: DepthRow[]; no: DepthRow[] }) {
+  const call = vi.fn(async (body: { name: string; inputs: Record<string, unknown> }) => {
+    if (body.name !== "get_market_depth") {
+      throw new Error(`unexpected action ${body.name}`);
+    }
+    const rows = (body.inputs.$outcome ? books.yes : books.no).map((row) => ({
+      price: row.price,
+      buy_volume: row.buy ?? 0,
+      sell_volume: row.sell ?? 0,
+    }));
+    return ok(rows);
+  });
+  return { call, action: makeAction(call as unknown as ReturnType<typeof vi.fn>) };
+}
+
+describe("OrderbookAction.getConsolidatedOrderBook", () => {
+  it("reads both outcomes' depth for the market", async () => {
+    const { call, action } = makeDepthAction({ yes: [], no: [] });
+
+    const book = await action.getConsolidatedOrderBook(419);
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call.mock.calls.map((c) => c[0].inputs)).toEqual([
+      { $query_id: 419, $outcome: true },
+      { $query_id: 419, $outcome: false },
+    ]);
+    expect(book).toEqual({
+      queryId: 419,
+      outcome: true,
+      bids: [],
+      asks: [],
+      isCrossed: false,
+    });
+  });
+
+  it("shows a NO ask at 93 as a YES bid at 7 of the same size", async () => {
+    // The case from truflation/website#4385: an ask for 4 shares of NO at 93c
+    // is economically a bid for 4 shares of YES at 7c, and the chain burns the
+    // pair to fill it.
+    const { action } = makeDepthAction({
+      yes: [],
+      no: [{ price: 93, sell: 4 }],
+    });
+
+    const book = await action.getConsolidatedOrderBook(419, true);
+
+    expect(book.bids).toEqual([{ price: 7, total: 4, native: 0, inverse: 4 }]);
+    expect(book.asks).toEqual([]);
+  });
+
+  it("shows a NO bid at 41 as a YES ask at 59", async () => {
+    const { action } = makeDepthAction({
+      yes: [],
+      no: [{ price: 41, buy: 200 }],
+    });
+
+    const book = await action.getConsolidatedOrderBook(419, true);
+
+    expect(book.asks).toEqual([{ price: 59, total: 200, native: 0, inverse: 200 }]);
+    expect(book.bids).toEqual([]);
+  });
+
+  it("merges native and inverse volume at one price and keeps the split", async () => {
+    const { action } = makeDepthAction({
+      yes: [{ price: 59, sell: 100 }],
+      no: [{ price: 41, buy: 200 }],
+    });
+
+    const book = await action.getConsolidatedOrderBook(419, true);
+
+    expect(book.asks).toEqual([{ price: 59, total: 300, native: 100, inverse: 200 }]);
+  });
+
+  it("sorts bids best-highest and asks best-lowest", async () => {
+    const { action } = makeDepthAction({
+      yes: [
+        { price: 60, sell: 100 },
+        { price: 30, buy: 10 },
+      ],
+      no: [
+        { price: 41, buy: 200 },
+        { price: 45, buy: 50 },
+        { price: 55, sell: 25 },
+      ],
+    });
+
+    const book = await action.getConsolidatedOrderBook(419, true);
+
+    expect(book.asks.map((l) => l.price)).toEqual([55, 59, 60]);
+    expect(book.bids.map((l) => l.price)).toEqual([45, 30]);
+  });
+
+  it("returns the NO book as the YES book reflected", async () => {
+    const books = {
+      yes: [
+        { price: 60, sell: 100 },
+        { price: 30, buy: 10 },
+      ],
+      no: [
+        { price: 41, buy: 200 },
+        { price: 55, sell: 25 },
+      ],
+    };
+    const yesBook = await makeDepthAction(books).action.getConsolidatedOrderBook(419, true);
+    const noBook = await makeDepthAction(books).action.getConsolidatedOrderBook(419, false);
+
+    expect(noBook.outcome).toBe(false);
+    // Price q on one side is 100 - q on the other, bids become asks, and what
+    // was native in the YES frame is inverse in the NO frame.
+    const mirror = (l: ConsolidatedLevel): ConsolidatedLevel => ({
+      price: 100 - l.price,
+      total: l.total,
+      native: l.inverse,
+      inverse: l.native,
+    });
+    expect(noBook.asks).toEqual(yesBook.bids.map(mirror));
+    expect(noBook.bids).toEqual(yesBook.asks.map(mirror));
+  });
+
+  it("reports a crossed book rather than hiding it", async () => {
+    // A YES bid at 61 and a NO bid at 45 read as a bid at 61 over an ask at 55.
+    // 61 + 45 is 106, so no mint fires and the crossing rests indefinitely.
+    const { action } = makeDepthAction({
+      yes: [{ price: 61, buy: 30 }],
+      no: [{ price: 45, buy: 30 }],
+    });
+
+    const book = await action.getConsolidatedOrderBook(419, true);
+
+    expect(book.bids[0].price).toBe(61);
+    expect(book.asks[0].price).toBe(55);
+    expect(book.isCrossed).toBe(true);
+  });
+
+  it("drops empty price levels and never reports an uncrossed book as crossed", async () => {
+    const { action } = makeDepthAction({
+      yes: [
+        { price: 40, buy: 0, sell: 0 },
+        { price: 45, buy: 10 },
+      ],
+      no: [{ price: 44, buy: 20 }],
+    });
+
+    const book = await action.getConsolidatedOrderBook(419, true);
+
+    expect(book.bids).toEqual([{ price: 45, total: 10, native: 10, inverse: 0 }]);
+    expect(book.asks).toEqual([{ price: 56, total: 20, native: 0, inverse: 20 }]);
+    expect(book.isCrossed).toBe(false);
   });
 });

--- a/src/contracts-api/orderbookAction.ts
+++ b/src/contracts-api/orderbookAction.ts
@@ -15,6 +15,7 @@ import {
   WalletPosition,
   DepthLevel,
   BestPrices,
+  ConsolidatedOrderBook,
   UserCollateral,
   DistributionSummary,
   LPRewardDetail,
@@ -68,6 +69,11 @@ import type {
   BucketDepth,
   MarketForecast,
 } from "../util/forecast";
+import {
+  consolidateSide,
+  depthAsks,
+  depthBids,
+} from "../util/consolidatedBook";
 
 /**
  * OrderbookAction provides methods for interacting with binary prediction markets.
@@ -668,6 +674,77 @@ export class OrderbookAction {
       bestBid: row.best_bid,
       bestAsk: row.best_ask,
       spread: row.spread,
+    };
+  }
+
+  /**
+   * Gets one outcome's order book with the opposite outcome's quotes folded in.
+   *
+   * `getMarketDepth` returns a single outcome's ladder, but a binary market's
+   * two books are two views of one position and the matching engine fills
+   * across them. A resting SELL NO at 93c is a standing offer that lets someone
+   * buy YES at 7c, and the chain will execute it. Reading only the YES book
+   * makes that quote invisible and the market look thinner than it is.
+   *
+   * So, in the YES frame:
+   *
+   *     consolidated bids = YES bids + (100 - p for every NO ask)
+   *     consolidated asks = YES asks + (100 - p for every NO bid)
+   *
+   * The sides swap: a NO ask arrives as a YES bid. Hitting it means both
+   * parties sell and the share pair burns; hitting a consolidated ask means
+   * both buy and a pair mints.
+   *
+   * **The result is not a sweepable ladder.** Mint and burn matches fire only
+   * when the two prices sum to exactly 100, while a direct same-outcome match
+   * crosses. So one order fills every native level past its limit plus exactly
+   * ONE inverse level, and walking these levels the way you would walk a
+   * regular ladder quotes fills the chain will not produce. Each level keeps
+   * `native` and `inverse` separately so a caller can price that correctly.
+   *
+   * Costs two `get_market_depth` reads, issued together.
+   *
+   * @param queryId - Market identifier
+   * @param outcome - The outcome to frame prices in: true=YES (default),
+   *   false=NO. The NO-framed book is the YES-framed book reflected, so one
+   *   call answers either tab.
+   * @returns Both consolidated ladders, best first, and whether they cross
+   *
+   * @example
+   * ```typescript
+   * const book = await orderbook.getConsolidatedOrderBook(419);
+   * for (const level of book.asks) {
+   *   console.log(level.price, level.total, level.native, level.inverse);
+   * }
+   * ```
+   */
+  async getConsolidatedOrderBook(
+    queryId: number,
+    outcome: boolean = true
+  ): Promise<ConsolidatedOrderBook> {
+    const [native, opposite] = await Promise.all([
+      this.getMarketDepth(queryId, outcome),
+      this.getMarketDepth(queryId, !outcome),
+    ]);
+
+    const bids = consolidateSide(
+      depthBids(native),
+      depthAsks(opposite),
+      "bid"
+    );
+    const asks = consolidateSide(
+      depthAsks(native),
+      depthBids(opposite),
+      "ask"
+    );
+
+    return {
+      queryId,
+      outcome,
+      bids,
+      asks,
+      isCrossed:
+        bids.length > 0 && asks.length > 0 && bids[0].price >= asks[0].price,
     };
   }
 

--- a/src/contracts-api/orderbookAction.ts
+++ b/src/contracts-api/orderbookAction.ts
@@ -682,9 +682,10 @@ export class OrderbookAction {
    *
    * `getMarketDepth` returns a single outcome's ladder, but a binary market's
    * two books are two views of one position and the matching engine fills
-   * across them. A resting SELL NO at 93c is a standing offer that lets someone
-   * buy YES at 7c, and the chain will execute it. Reading only the YES book
-   * makes that quote invisible and the market look thinner than it is.
+   * across them. A resting SELL NO at 93c is a standing BID for YES at 7c: a
+   * trader hits it by SELLING YES, both sides sell, and the chain burns the
+   * share pair. Reading only the YES book makes that quote invisible and the
+   * market look thinner than it is.
    *
    * So, in the YES frame:
    *
@@ -702,7 +703,10 @@ export class OrderbookAction {
    * regular ladder quotes fills the chain will not produce. Each level keeps
    * `native` and `inverse` separately so a caller can price that correctly.
    *
-   * Costs two `get_market_depth` reads, issued together.
+   * Costs two `get_market_depth` reads. They are issued together, but the node
+   * exposes no way to pin both to one block, so on a moving book the two sides
+   * can come from adjacent heights and `isCrossed` is best-effort. Do not treat
+   * a crossed result as a settled arbitrage without re-reading.
    *
    * @param queryId - Market identifier
    * @param outcome - The outcome to frame prices in: true=YES (default),

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -139,6 +139,8 @@ export type {
   WalletPosition,
   DepthLevel,
   BestPrices,
+  ConsolidatedLevel,
+  ConsolidatedOrderBook,
   UserCollateral,
   DistributionSummary,
   LPRewardDetail,
@@ -208,6 +210,15 @@ export type {
 
 export { bucketBoundsFromMarketData } from "./util/marketBuckets";
 export type { BucketBounds } from "./util/marketBuckets";
+
+// Consolidating a market's two outcome books into one executable ladder.
+export {
+  consolidateSide,
+  inversePrice,
+  depthBids,
+  depthAsks,
+} from "./util/consolidatedBook";
+export type { BookSide } from "./util/consolidatedBook";
 
 // Local actions types
 export type {

--- a/src/types/orderbook.ts
+++ b/src/types/orderbook.ts
@@ -178,6 +178,46 @@ export interface BestPrices {
   spread: number | null;
 }
 
+/**
+ * One price level of a consolidated order book, in the requested outcome's
+ * frame.
+ *
+ * `native` rests in this outcome's own book and fills as a direct match.
+ * `inverse` rests in the opposite outcome's book at `100 - price`, and fills by
+ * minting a share pair on the ask side or burning one on the bid side.
+ */
+export interface ConsolidatedLevel {
+  /** Price level in cents, 1-99 */
+  price: number;
+  /** Shares available here, native + inverse */
+  total: number;
+  /** Shares resting in this outcome's own book */
+  native: number;
+  /** Shares resting in the opposite outcome's book at 100 - price */
+  inverse: number;
+}
+
+/** One outcome's order book with the opposite outcome's quotes folded in */
+export interface ConsolidatedOrderBook {
+  /** Market identifier */
+  queryId: number;
+  /** The outcome the prices are framed in: true=YES, false=NO */
+  outcome: boolean;
+  /** Executable bids, best (highest) first */
+  bids: ConsolidatedLevel[];
+  /** Executable asks, best (lowest) first */
+  asks: ConsolidatedLevel[];
+  /**
+   * Whether the best bid sits at or above the best ask.
+   *
+   * A consolidated book can be crossed and stay that way. A YES bid at 61 and a
+   * NO bid at 45 read as a bid at 61 over an ask at 55, and the engine will
+   * never match them because 61 + 45 is not 100. Render it rather than treating
+   * it as bad data.
+   */
+  isCrossed: boolean;
+}
+
 /** User's locked collateral across all markets */
 export interface UserCollateral {
   /** Total locked collateral in wei (NUMERIC(78,0) as string) */

--- a/src/util/consolidatedBook.ts
+++ b/src/util/consolidatedBook.ts
@@ -1,0 +1,108 @@
+/**
+ * Folding a market's two outcome books into the one ladder a trader can hit.
+ *
+ * A binary market's YES and NO books are two views of one position, and the
+ * matching engine treats them that way. A resting SELL NO at p burn-matches an
+ * incoming SELL YES at 100-p, and a resting BUY NO at p mint-matches an
+ * incoming BUY YES at 100-p. So, in the YES frame:
+ *
+ *     consolidated bids = yesBids + (100 - p for every NO ask)
+ *     consolidated asks = yesAsks + (100 - p for every NO bid)
+ *
+ * The sides swap. A NO ask is a YES bid, because hitting it means both parties
+ * sell and the pair burns. Verified on testnet (2026-08-03).
+ *
+ * Mint and burn both require the two prices to sum to EXACTLY 100: `match_mint`
+ * and `match_burn` in the node's 032-order-book-actions.sql return early
+ * otherwise, and select the resting order with `price =` rather than a range.
+ * Only a direct same-outcome match crosses prices. That is why every level here
+ * carries its native and inverse volume separately instead of only the sum: one
+ * order sweeps every native level past its limit but exactly ONE inverse level,
+ * so anything quoting a fill needs the split to get the answer right.
+ */
+
+import type { ConsolidatedLevel, DepthLevel } from "../types/orderbook";
+
+/** One resting level: price in cents (positive, 1-99), size in shares. */
+export interface BookLevel {
+  /** Price in cents, positive, 1-99. */
+  price: number;
+  /** Size in shares. */
+  size: number;
+}
+
+/** Which way a consolidated side sorts: bids best-highest, asks best-lowest. */
+export type BookSide = "bid" | "ask";
+
+/** A YES price and its NO price always sum to this. */
+const COMPLEMENT = 100;
+
+/** Kill float drift from the complement of a fractional price. */
+function round4(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}
+
+/** The price in the opposite outcome's frame that this price is hittable at. */
+export function inversePrice(price: number): number {
+  return round4(COMPLEMENT - price);
+}
+
+/**
+ * One side of a consolidated ladder: this outcome's own levels plus the
+ * opposite outcome's levels inverted into this frame.
+ *
+ * Pass the opposite side of the opposite book. Consolidated bids take the
+ * opposite outcome's asks; consolidated asks take its bids.
+ *
+ * Levels that land on the same price merge into one entry that keeps the
+ * native/inverse split. Zero and negative sizes are dropped.
+ */
+export function consolidateSide(
+  native: readonly BookLevel[],
+  opposite: readonly BookLevel[],
+  side: BookSide
+): ConsolidatedLevel[] {
+  const byPrice = new Map<number, ConsolidatedLevel>();
+
+  const add = (price: number, size: number, source: "native" | "inverse") => {
+    if (!(size > 0)) return;
+    let level = byPrice.get(price);
+    if (!level) {
+      level = { price, total: 0, native: 0, inverse: 0 };
+      byPrice.set(price, level);
+    }
+    level[source] += size;
+    level.total += size;
+  };
+
+  for (const level of native) add(level.price, level.size, "native");
+  for (const level of opposite) {
+    add(inversePrice(level.price), level.size, "inverse");
+  }
+
+  const levels = [...byPrice.values()];
+  levels.sort((a, b) => (side === "bid" ? b.price - a.price : a.price - b.price));
+  return levels;
+}
+
+/** The buy orders in a depth ladder, as levels. */
+export function depthBids(depth: readonly DepthLevel[]): BookLevel[] {
+  const levels: BookLevel[] = [];
+  for (const level of depth) {
+    if (level.buyVolume > 0) {
+      levels.push({ price: level.price, size: level.buyVolume });
+    }
+  }
+  return levels;
+}
+
+/** The sell orders in a depth ladder, as levels. */
+export function depthAsks(depth: readonly DepthLevel[]): BookLevel[] {
+  const levels: BookLevel[] = [];
+  for (const level of depth) {
+    if (level.sellVolume > 0) {
+      levels.push({ price: level.price, size: level.sellVolume });
+    }
+  }
+  return levels;
+}

--- a/src/util/forecast.ts
+++ b/src/util/forecast.ts
@@ -96,6 +96,9 @@
 // has no standard-library answer for. If it is ever wired back up upstream, it
 // has to be written here from scratch, not ported.
 
+import { consolidateSide } from "./consolidatedBook";
+import type { BookLevel } from "./consolidatedBook";
+
 /** A bracket at least this wide contributes essentially nothing. */
 const MIN_CONFIDENCE = 1e-3;
 
@@ -150,13 +153,7 @@ export type ForecastBasis = "interior" | "tail" | "unresolved";
 /** How the point estimate was produced. */
 export type ForecastMethod = "rank" | "discrete";
 
-/** One resting level: price in cents (positive, 1-99), size in shares. */
-export interface BookLevel {
-  /** Price in cents, positive, 1-99. */
-  price: number;
-  /** Size in shares. */
-  size: number;
-}
+export type { BookLevel };
 
 /**
  * One bucket's bounds and its best two-sided quote, in cents.
@@ -308,11 +305,6 @@ export function forecastToJSON(forecast: MarketForecast): MarketForecastJSON {
 // Quote helpers
 // ============================================
 
-/** Prices are cent-denominated; keep the inverted ones off float dust. */
-function round4(value: number): number {
-  return Math.round(value * 1e4) / 1e4;
-}
-
 /**
  * Resolve an exact `.5` tie to even, the way Python's format spec does.
  *
@@ -380,35 +372,27 @@ export function usableAsk(book: BucketBook): number | null {
 /**
  * The bucket's executable bid ladder: its YES bids plus every NO ask inverted
  * to the YES price it is hittable at. Best (highest) first.
+ *
+ * A native and an inverted level landing on the same price merge into one
+ * entry. Everything downstream here sums price x size or walks the ladder in
+ * price order, so merging leaves the forecast numbers unchanged. Callers that
+ * need the native/inverse split should use {@link consolidateSide} directly.
  */
 export function consolidatedBids(depth: BucketDepth): BookLevel[] {
-  const levels: BookLevel[] = [];
-  for (const level of depth.yesBids ?? []) {
-    if (level.size > 0) levels.push(level);
-  }
-  for (const level of depth.noAsks ?? []) {
-    if (level.size > 0) {
-      levels.push({ price: round4(100 - level.price), size: level.size });
-    }
-  }
-  return levels.sort((a, b) => b.price - a.price);
+  return consolidateSide(depth.yesBids ?? [], depth.noAsks ?? [], "bid").map(
+    (level) => ({ price: level.price, size: level.total })
+  );
 }
 
 /**
  * The bucket's executable ask ladder: its YES asks plus every NO bid inverted
- * to the YES price it is hittable at. Best (lowest) first.
+ * to the YES price it is hittable at. Best (lowest) first. Same-price levels
+ * merge, as in {@link consolidatedBids}.
  */
 export function consolidatedAsks(depth: BucketDepth): BookLevel[] {
-  const levels: BookLevel[] = [];
-  for (const level of depth.yesAsks ?? []) {
-    if (level.size > 0) levels.push(level);
-  }
-  for (const level of depth.noBids ?? []) {
-    if (level.size > 0) {
-      levels.push({ price: round4(100 - level.price), size: level.size });
-    }
-  }
-  return levels.sort((a, b) => a.price - b.price);
+  return consolidateSide(depth.yesAsks ?? [], depth.noBids ?? [], "ask").map(
+    (level) => ({ price: level.price, size: level.total })
+  );
 }
 
 /** The consolidated best quotes, for the spread and dutch-book helpers. */


### PR DESCRIPTION
`getMarketDepth` returns one outcome's ladder, but a binary market's two books are two views of one position and the matching engine fills across them. A resting SELL NO at 93c is a standing **bid** for YES at 7c: a trader hits it by **selling** YES, both sides sell, and the chain burns the share pair. Read only the YES book and that quote is invisible, so the market reads thinner and worse-priced than it is.

`orderbook.getConsolidatedOrderBook(queryId, outcome = true)` folds them together, in the YES frame:

```
consolidated bids = YES bids + (100 - p for every NO ask)
consolidated asks = YES asks + (100 - p for every NO bid)
```

The sides swap. A NO ask arrives as a YES bid, because hitting it means both parties sell and the pair burns; hitting a consolidated ask means both buy and a pair mints.

```typescript
const book = await orderbook.getConsolidatedOrderBook(419);
for (const level of book.asks) {
  console.log(level.price, level.total, level.native, level.inverse);
}
```

## This is not a sweepable ladder

A direct same-outcome match crosses prices. `match_mint` and `match_burn` fire only when the two prices sum to exactly 100: they return early otherwise, and select the resting order with `price =` rather than a range. So one order fills every native level past its limit plus exactly **one** inverse level.

Walking these levels the way you would walk `getMarketDepth` quotes fills the chain will not produce. That is why each level keeps `native` and `inverse` separately instead of only their sum, so a caller can price the fill correctly.

A consolidated book can also sit crossed indefinitely, which `isCrossed` reports. A YES bid at 61 against a NO bid at 45 shows a bid at 61 over an ask at 55, and 61 + 45 is not 100, so nothing matches and the crossing rests until someone reprices.

## What changed

- `src/util/consolidatedBook.ts`, new: the mapping itself, as `consolidateSide`, `inversePrice`, `depthBids` and `depthAsks`.
- `getConsolidatedOrderBook` in `src/contracts-api/orderbookAction.ts`. Two `getMarketDepth` reads, issued together.
- `ConsolidatedLevel` and `ConsolidatedOrderBook` in `src/types/orderbook.ts`, exported from `src/internal.ts`.
- `consolidatedBids` / `consolidatedAsks` in the forecast module now call the shared helper rather than carrying their own copy of the inversion. They merge same-price levels as a result; the forecast only sums `price x size` or walks the ladder in price order, so its numbers are unchanged, and there is a test asserting exactly that.
- README and `docs/api-reference.md`.

## Testing

8 new unit tests in `orderbookAction.test.ts`, including the case from the linked issue verbatim (a NO ask for 4 shares at 93 surfacing as a YES bid for 4 at 7), the same-price merge keeping its split, the NO frame reflecting the YES frame, and the crossed book.

`npm run test:unit` passes 413 tests, `npm run typecheck` and `npm run build` are clean.

resolves: https://github.com/truflation/website/issues/4388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `getConsolidatedOrderBook` to combine direct and inverse outcome liquidity into a single bid/ask view.
  * Added support for outcome selection, native and inverse volume visibility, consolidated price levels, and crossed-book detection.
  * Added exported order book types and utilities for working with consolidated liquidity.

* **Documentation**
  * Added API reference documentation and README examples covering consolidated order book usage and iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
