### PR TITLE
feat: read a consolidated book from a single chain read

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ For other bundlers or serverless platforms, consult their documentation on modul
 | Place split limit order | `orderbook.placeSplitLimitOrder({queryId, truePrice, amount})` |
 | Get order book | `orderbook.getOrderBook(queryId, outcome)` |
 | Get consolidated order book | `orderbook.getConsolidatedOrderBook(queryId, outcome)` |
+| Get both outcomes' depth | `orderbook.getFullMarketDepth(queryId)` |
 | Get best prices | `orderbook.getBestPrices(queryId, outcome)` |
 | Destroy stream | `client.destroyStream(streamLocator)` |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1494,6 +1494,28 @@ for (const level of depth) {
 }
 ```
 
+#### `orderbook.getFullMarketDepth(queryId: number): Promise<FullDepthLevel[]>`
+
+Gets aggregated volume at each price level for **both** outcomes, from one read.
+
+Same aggregation as `getMarketDepth`, for the whole market instead of one
+outcome, with each level tagged by the outcome it rests on. Rows arrive YES first
+then NO, price ascending within each.
+
+One statement means one snapshot. Anything comparing the two outcomes to each
+other wants this rather than two `getMarketDepth` calls, because between two
+calls an order can land on one side and not the other. `getMarketDepth` is
+unchanged and stays the right call when you want one outcome — a depth chart, a
+market-making bot quoting one side.
+
+```typescript
+const depth = await orderbook.getFullMarketDepth(queryId);
+for (const level of depth) {
+  const side = level.outcome ? "YES" : "NO";
+  console.log(`${side} ${level.price}c: ${level.buyVolume} buy, ${level.sellVolume} sell`);
+}
+```
+
 #### `orderbook.getConsolidatedOrderBook(queryId: number, outcome?: boolean): Promise<ConsolidatedOrderBook>`
 
 Gets one outcome's book with the opposite outcome's quotes folded in, so you see
@@ -1509,10 +1531,12 @@ consolidated asks = YES asks + (100 - p for every NO bid)
 ```
 
 The sides swap: a NO ask arrives as a YES bid. `outcome` defaults to `true`, and
-the NO-framed book is the YES-framed book reflected. Costs two `getMarketDepth`
-reads. They are issued together, but the node exposes no way to pin both to one
-block, so on a moving book the two sides can come from adjacent heights and
-`isCrossed` is best-effort.
+the NO-framed book is the YES-framed book reflected. Costs one
+`getFullMarketDepth` read, so both sides are one snapshot of the chain and
+`isCrossed` describes a state the book was really in. This used to take two
+`getMarketDepth` calls, where an order landing between them could make the
+stitched ladder read as crossed when neither height was. Requires a node carrying
+`get_full_market_depth`.
 
 ```typescript
 const book = await orderbook.getConsolidatedOrderBook(queryId);

--- a/src/contracts-api/orderbookAction.test.ts
+++ b/src/contracts-api/orderbookAction.test.ts
@@ -156,22 +156,31 @@ describe("OrderbookAction.getCollateralByWallet", () => {
 
 /**
  * getConsolidatedOrderBook: the two outcome books folded into the one ladder a
- * trader can actually hit. The mapping is arithmetic on two get_market_depth
- * reads, so it is fully testable against a mocked client. What matters is that
- * the SIDES swap (a NO ask is a YES bid, not a YES ask) and that each level
- * keeps its native/inverse split, since mint and burn only fire at the exact
- * complement and a caller quoting a fill needs to know which is which.
+ * trader can actually hit. The mapping is arithmetic on one get_full_market_depth
+ * read, so it is fully testable against a mocked client. What matters is that the
+ * SIDES swap (a NO ask is a YES bid, not a YES ask) and that each level keeps its
+ * native/inverse split, since mint and burn only fire at the exact complement and
+ * a caller quoting a fill needs to know which is which.
+ *
+ * The read is one call because both sides have to describe the same moment. Two
+ * calls let an order land between them, and the stitched ladder can then read as
+ * crossed when neither height was.
  */
 
-/** One depth row as get_market_depth returns it: price plus both volumes. */
+/** One depth row as get_full_market_depth returns it, before its outcome tag. */
 type DepthRow = { price: number; buy?: number; sell?: number };
 
 function makeDepthAction(books: { yes: DepthRow[]; no: DepthRow[] }) {
   const call = vi.fn(async (body: { name: string; inputs: Record<string, unknown> }) => {
-    if (body.name !== "get_market_depth") {
+    if (body.name !== "get_full_market_depth") {
       throw new Error(`unexpected action ${body.name}`);
     }
-    const rows = (body.inputs.$outcome ? books.yes : books.no).map((row) => ({
+    // YES levels first then NO, as the action orders them.
+    const rows = [
+      ...books.yes.map((row) => ({ ...row, outcome: true })),
+      ...books.no.map((row) => ({ ...row, outcome: false })),
+    ].map((row) => ({
+      outcome: row.outcome,
       price: row.price,
       buy_volume: row.buy ?? 0,
       sell_volume: row.sell ?? 0,
@@ -181,17 +190,44 @@ function makeDepthAction(books: { yes: DepthRow[]; no: DepthRow[] }) {
   return { call, action: makeAction(call as unknown as ReturnType<typeof vi.fn>) };
 }
 
+describe("OrderbookAction.getFullMarketDepth", () => {
+  it("reads the whole market in one call and keeps each level's outcome", async () => {
+    const { call, action } = makeDepthAction({
+      yes: [{ price: 55, buy: 150 }],
+      no: [{ price: 40, sell: 100 }],
+    });
+
+    const depth = await action.getFullMarketDepth(419);
+
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(call.mock.calls[0][0].inputs).toEqual({ $query_id: 419 });
+    expect(depth).toEqual([
+      { outcome: true, price: 55, buyVolume: 150, sellVolume: 0 },
+      { outcome: false, price: 40, buyVolume: 0, sellVolume: 100 },
+    ]);
+  });
+
+  it("throws on a non-200 status", async () => {
+    const call = vi.fn(async () => ({ status: 503, data: undefined }));
+    const action = makeAction(call as unknown as ReturnType<typeof vi.fn>);
+
+    await expect(action.getFullMarketDepth(419)).rejects.toThrow(
+      "Failed to get full market depth: 503",
+    );
+  });
+});
+
 describe("OrderbookAction.getConsolidatedOrderBook", () => {
-  it("reads both outcomes' depth for the market", async () => {
+  it("reads the whole book in one call rather than one call per outcome", async () => {
     const { call, action } = makeDepthAction({ yes: [], no: [] });
 
     const book = await action.getConsolidatedOrderBook(419);
 
-    expect(call).toHaveBeenCalledTimes(2);
-    expect(call.mock.calls.map((c) => c[0].inputs)).toEqual([
-      { $query_id: 419, $outcome: true },
-      { $query_id: 419, $outcome: false },
-    ]);
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(call.mock.calls[0][0]).toMatchObject({
+      name: "get_full_market_depth",
+      inputs: { $query_id: 419 },
+    });
     expect(book).toEqual({
       queryId: 419,
       outcome: true,
@@ -226,6 +262,20 @@ describe("OrderbookAction.getConsolidatedOrderBook", () => {
 
     expect(book.asks).toEqual([{ price: 59, total: 200, native: 0, inverse: 200 }]);
     expect(book.bids).toEqual([]);
+  });
+
+  it("routes a level by its outcome tag, not by its price", async () => {
+    // Both sells sit at 60 in their own book. The YES one is an ask at 60; the
+    // NO one is a bid at 40. Read the tag wrong and they land on the same side.
+    const { action } = makeDepthAction({
+      yes: [{ price: 60, sell: 10 }],
+      no: [{ price: 60, sell: 20 }],
+    });
+
+    const book = await action.getConsolidatedOrderBook(419, true);
+
+    expect(book.asks).toEqual([{ price: 60, total: 10, native: 10, inverse: 0 }]);
+    expect(book.bids).toEqual([{ price: 40, total: 20, native: 0, inverse: 20 }]);
   });
 
   it("merges native and inverse volume at one price and keeps the split", async () => {

--- a/src/contracts-api/orderbookAction.ts
+++ b/src/contracts-api/orderbookAction.ts
@@ -14,6 +14,7 @@ import {
   UserPosition,
   WalletPosition,
   DepthLevel,
+  FullDepthLevel,
   BestPrices,
   ConsolidatedOrderBook,
   UserCollateral,
@@ -37,6 +38,7 @@ import {
   RawUserPosition,
   RawWalletPosition,
   RawDepthLevel,
+  RawFullDepthLevel,
   RawBestPrices,
   RawUserCollateral,
   RawMarketValidation,
@@ -73,6 +75,7 @@ import {
   consolidateSide,
   depthAsks,
   depthBids,
+  splitFullDepth,
 } from "../util/consolidatedBook";
 
 /**
@@ -641,6 +644,45 @@ export class OrderbookAction {
   }
 
   /**
+   * Gets aggregated market depth for BOTH outcomes, from one read.
+   *
+   * Same aggregation as `getMarketDepth`, for the whole market instead of one
+   * outcome, with each level tagged by the outcome it rests on. Rows arrive YES
+   * first then NO, price ascending within each.
+   *
+   * One statement means one snapshot. Anything that compares the two outcomes to
+   * each other wants this rather than two `getMarketDepth` calls, because between
+   * two calls an order can land on one side and not the other.
+   *
+   * @param queryId - Market identifier
+   * @returns Every price level in the market, tagged with its outcome
+   */
+  async getFullMarketDepth(queryId: number): Promise<FullDepthLevel[]> {
+    const result = await this.kwilClient.call(
+      {
+        namespace: "main",
+        name: "get_full_market_depth",
+        inputs: {
+          $query_id: queryId,
+        },
+      },
+      this.kwilSigner
+    );
+
+    if (result.status !== 200) {
+      throw new Error(`Failed to get full market depth: ${result.status}`);
+    }
+
+    const rows = (result.data?.result as RawFullDepthLevel[]) || [];
+    return rows.map((row) => ({
+      outcome: row.outcome,
+      price: Number(row.price),
+      buyVolume: Number(row.buy_volume),
+      sellVolume: Number(row.sell_volume),
+    }));
+  }
+
+  /**
    * Gets the best bid and ask prices for an outcome.
    *
    * @param queryId - Market identifier
@@ -703,10 +745,12 @@ export class OrderbookAction {
    * regular ladder quotes fills the chain will not produce. Each level keeps
    * `native` and `inverse` separately so a caller can price that correctly.
    *
-   * Costs two `get_market_depth` reads. They are issued together, but the node
-   * exposes no way to pin both to one block, so on a moving book the two sides
-   * can come from adjacent heights and `isCrossed` is best-effort. Do not treat
-   * a crossed result as a settled arbitrage without re-reading.
+   * Costs one `get_full_market_depth` read, so both sides are one snapshot of
+   * the chain and `isCrossed` describes a state the book was really in. This
+   * used to take two `get_market_depth` calls, where an order landing between
+   * them could make the stitched ladder read as crossed when neither height was.
+   *
+   * Requires a node carrying `get_full_market_depth`.
    *
    * @param queryId - Market identifier
    * @param outcome - The outcome to frame prices in: true=YES (default),
@@ -726,10 +770,8 @@ export class OrderbookAction {
     queryId: number,
     outcome: boolean = true
   ): Promise<ConsolidatedOrderBook> {
-    const [native, opposite] = await Promise.all([
-      this.getMarketDepth(queryId, outcome),
-      this.getMarketDepth(queryId, !outcome),
-    ]);
+    const depth = await this.getFullMarketDepth(queryId);
+    const { native, opposite } = splitFullDepth(depth, outcome);
 
     const bids = consolidateSide(
       depthBids(native),

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -138,6 +138,7 @@ export type {
   UserPosition,
   WalletPosition,
   DepthLevel,
+  FullDepthLevel,
   BestPrices,
   ConsolidatedLevel,
   ConsolidatedOrderBook,
@@ -217,6 +218,7 @@ export {
   inversePrice,
   depthBids,
   depthAsks,
+  splitFullDepth,
 } from "./util/consolidatedBook";
 export type { BookSide } from "./util/consolidatedBook";
 

--- a/src/types/orderbook.ts
+++ b/src/types/orderbook.ts
@@ -168,6 +168,24 @@ export interface DepthLevel {
   sellVolume: number;
 }
 
+/**
+ * Aggregated depth at one outcome's price level, as `get_full_market_depth`
+ * returns it.
+ *
+ * The outcome tag is what a `DepthLevel` leaves implicit, because the call it
+ * comes from asked for one outcome.
+ */
+export interface FullDepthLevel {
+  /** The outcome this level rests on: true=YES, false=NO */
+  outcome: boolean;
+  /** Price level in cents */
+  price: number;
+  /** Total shares in buy orders at this outcome and price */
+  buyVolume: number;
+  /** Total shares in sell orders at this outcome and price */
+  sellVolume: number;
+}
+
 /** Best bid/ask prices for a market outcome */
 export interface BestPrices {
   /** Best bid price (null if no bids) */
@@ -470,6 +488,14 @@ export interface RawWalletPosition {
 
 /** @internal Raw depth level from database */
 export interface RawDepthLevel {
+  price: number | string;
+  buy_volume: number | string;
+  sell_volume: number | string;
+}
+
+/** @internal Raw full depth level from database */
+export interface RawFullDepthLevel {
+  outcome: boolean;
   price: number | string;
   buy_volume: number | string;
   sell_volume: number | string;

--- a/src/util/consolidatedBook.ts
+++ b/src/util/consolidatedBook.ts
@@ -21,7 +21,11 @@
  * so anything quoting a fill needs the split to get the answer right.
  */
 
-import type { ConsolidatedLevel, DepthLevel } from "../types/orderbook";
+import type {
+  ConsolidatedLevel,
+  DepthLevel,
+  FullDepthLevel,
+} from "../types/orderbook";
 
 /** One resting level: price in cents (positive, 1-99), size in shares. */
 export interface BookLevel {
@@ -83,6 +87,33 @@ export function consolidateSide(
   const levels = [...byPrice.values()];
   levels.sort((a, b) => (side === "bid" ? b.price - a.price : a.price - b.price));
   return levels;
+}
+
+/**
+ * Separates a whole-market depth read into the ladder for the requested outcome
+ * and the ladder for the other one.
+ *
+ * The outcome tag is the only thing that distinguishes the two here: prices stay
+ * in each outcome's own frame, and inverting the opposite side into this frame is
+ * `consolidateSide`'s job.
+ */
+export function splitFullDepth(
+  depth: readonly FullDepthLevel[],
+  outcome: boolean
+): { native: DepthLevel[]; opposite: DepthLevel[] } {
+  const native: DepthLevel[] = [];
+  const opposite: DepthLevel[] = [];
+
+  for (const level of depth) {
+    const target = level.outcome === outcome ? native : opposite;
+    target.push({
+      price: level.price,
+      buyVolume: level.buyVolume,
+      sellVolume: level.sellVolume,
+    });
+  }
+
+  return { native, opposite };
 }
 
 /** The buy orders in a depth ladder, as levels. */


### PR DESCRIPTION
`getConsolidatedOrderBook` now reads the whole market with one
`get_full_market_depth` call instead of one `getMarketDepth` call per outcome, so
the two sides of the ladder describe the same moment.

## Why

A consolidated ladder only means anything if both sides come from the same state
of the chain. Reading YES and NO separately reads them at two independent points
in time, and an order landing between the two appears on one side and not the
other. The stitched ladder can then show a bid above an ask that never existed at
any single moment — which is why `isCrossed` shipped documented as best-effort.

The node now answers the whole book in one statement, so that whole class of
artifact goes away.

## What is in it

- `getFullMarketDepth(queryId)`, mapping to the node's `get_full_market_depth`.
  Same aggregation as `getMarketDepth`, for both outcomes, each level tagged with
  the outcome it rests on.
- `splitFullDepth` in `util/consolidatedBook.ts` separates that read back into the
  requested outcome's ladder and the other one's. The inversion into one frame is
  still `consolidateSide`'s job and is untouched.
- `getConsolidatedOrderBook` calls the new read and splits, instead of awaiting
  two depth calls. Return shape is unchanged, so nothing downstream needs an edit.
- The not-atomic caveat is gone from the doc comment and from
  `docs/api-reference.md`, because it is no longer true.
- Tests: the mocked client now serves `get_full_market_depth`, and the suite
  asserts one call rather than two. New cases cover the read itself and one that
  a level is routed by its outcome tag rather than its price — a YES sell at 60
  and a NO sell at 60 belong on opposite sides of the ladder, and a tag mixup
  produces a plausible-looking book with every quote on the wrong side.

## What is not in it

`getMarketDepth` is untouched and stays the right call for one outcome — a depth
chart, or a bot quoting one side.

`getMarketForecast` still reads each bucket's two books separately. It could move
to the new read and halve its calls, but it consumes individual orders from
`getOrderBook` rather than aggregated depth, so that is its own change with its
own review.

A fallback to the old two-read path when the node does not carry the action was
considered and dropped. It would make `isCrossed` atomic sometimes and not
others, with no way for a caller to tell which they got — which is the ambiguity
this PR exists to remove.

## Testing

`pnpm test:unit` (416 tests) and `pnpm run typecheck`, both clean.

The mapping itself is arithmetic, so it is fully covered against a mocked client.
What no unit test can cover is that the SDK reads the chain the right way round;
that is the live check in sdk-go's `consolidated_order_book_test.go`, which needs
a network carrying the action.

## Before publishing

The latest node release is v2.5.5, from before the action merged, so no network
serves `get_full_market_depth` yet. Merging is fine; publishing a version that
calls it is not, until a node release carrying it is out and rolled to the
networks that consumers read from.

## Follow-ups

The same change lands in sdk-go alongside this one; sdk-py follows from there.

This is one of two SDK pull requests closing that Problem — sdk-go carries the
same change. Whichever merges first will close it, so reopen it until the other
one lands.

resolves: https://github.com/truflation/website/issues/4445


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving complete market depth for both outcomes in a single snapshot.
  * Consolidated order books now separate and preserve depth levels by outcome, price, and volume.
* **Bug Fixes**
  * Improved consistency when identifying crossed order books.
* **Documentation**
  * Added API and quick-reference documentation for full market-depth retrieval and updated consolidated order-book behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->